### PR TITLE
Fix bug with missing join state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,6 @@ libraryDependencies ++= Seq(
   "redis.clients"         % "jedis"                      % "3.7.1",
   "org.scala-lang"        % "scala-reflect"              % scalaVersion.value,
   "com.google.guava"      % "guava"                      % "30.1.1-jre",
-  "org.apache.lucene"     % "lucene-core"                % luceneVersion,
-  "org.apache.lucene"     % "lucene-analyzers-icu"       % luceneVersion,
   "io.findify"           %% "featury-flink"              % featuryVersion,
   "io.findify"           %% "featury-redis"              % featuryVersion,
   "org.apache.flink"     %% "flink-scala"                % flinkVersion,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,7 +8,7 @@ object Deps {
   lazy val circeYamlVersion = "0.14.1"
   lazy val fs2Version       = "3.2.2"
   lazy val flinkVersion     = "1.14.2"
-  lazy val featuryVersion   = "0.3.0-M7-SNAPSHOT"
+  lazy val featuryVersion   = "0.3.0-M8-SNAPSHOT"
 
   val httpsDeps = Seq(
     "org.http4s" %% "http4s-dsl"          % http4sVersion,

--- a/src/main/scala/ai/metarank/flow/EventStateJoin.scala
+++ b/src/main/scala/ai/metarank/flow/EventStateJoin.scala
@@ -8,7 +8,8 @@ import io.findify.featury.model.{FeatureValue, Key}
 object EventStateJoin extends Join[EventState] {
   override def by(left: EventState): Key.Tenant = Tenant(left.event.tenant)
 
-  override def tags(left: EventState): List[Key.Tag] = ClickthroughJoin.scopes.flatMap(_.tags(left.event))
+  override def tags(left: EventState): List[Key.Tag] =
+    ClickthroughJoin.scopes.flatMap(_.tags(left.event))
 
   override def join(left: EventState, values: List[FeatureValue]): EventState =
     left.copy(state = left.state ++ values.map(fv => fv.key -> fv).toMap)

--- a/src/main/scala/ai/metarank/mode/TypeInfos.scala
+++ b/src/main/scala/ai/metarank/mode/TypeInfos.scala
@@ -5,17 +5,17 @@ import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, RankingEvent}
 import io.findify.featury.model.{FeatureValue, Key, Scalar, State, Write}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import scala.language.higherKinds
-import org.apache.flink.api.scala._
+import io.findify.flinkadt.api._
 
 object TypeInfos {
-  implicit lazy val stateInfo: TypeInformation[State]                  = createTypeInformation[State]
-  implicit lazy val rankInfo: TypeInformation[RankingEvent]            = createTypeInformation[RankingEvent]
-  implicit lazy val interactionInfo: TypeInformation[InteractionEvent] = createTypeInformation[InteractionEvent]
-  implicit lazy val feedbackInfo: TypeInformation[FeedbackEvent]       = createTypeInformation[FeedbackEvent]
-  implicit lazy val eventInfo: TypeInformation[Event]                  = createTypeInformation[Event]
-  implicit lazy val clickthroughInfo: TypeInformation[Clickthrough]    = createTypeInformation[Clickthrough]
-  implicit lazy val writeInfo: TypeInformation[Write]                  = createTypeInformation[Write]
-  implicit lazy val keyInfo: TypeInformation[Key]                      = createTypeInformation[Key]
-  implicit lazy val featureValueInfo: TypeInformation[FeatureValue]    = createTypeInformation[FeatureValue]
-  implicit lazy val scalarInfo: TypeInformation[Scalar]                = createTypeInformation[Scalar]
+  implicit lazy val stateInfo: TypeInformation[State]                  = deriveTypeInformation[State]
+  implicit lazy val rankInfo: TypeInformation[RankingEvent]            = deriveTypeInformation[RankingEvent]
+  implicit lazy val interactionInfo: TypeInformation[InteractionEvent] = deriveTypeInformation[InteractionEvent]
+  implicit lazy val feedbackInfo: TypeInformation[FeedbackEvent]       = deriveTypeInformation[FeedbackEvent]
+  implicit lazy val eventInfo: TypeInformation[Event]                  = deriveTypeInformation[Event]
+  implicit lazy val clickthroughInfo: TypeInformation[Clickthrough]    = deriveTypeInformation[Clickthrough]
+  implicit lazy val writeInfo: TypeInformation[Write]                  = deriveTypeInformation[Write]
+  implicit lazy val keyInfo: TypeInformation[Key]                      = deriveTypeInformation[Key]
+  implicit lazy val featureValueInfo: TypeInformation[FeatureValue]    = deriveTypeInformation[FeatureValue]
+  implicit lazy val scalarInfo: TypeInformation[Scalar]                = deriveTypeInformation[Scalar]
 }

--- a/src/main/scala/ai/metarank/mode/inference/FeedbackFlow.scala
+++ b/src/main/scala/ai/metarank/mode/inference/FeedbackFlow.scala
@@ -15,7 +15,6 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings
 import org.apache.flink.streaming.util.TestStreamEnvironment
-import org.apache.flink.test.util.MiniClusterWithClientResource
 
 object FeedbackFlow extends Logging {
   import ai.metarank.flow.DataStreamOps._

--- a/src/main/scala/ai/metarank/mode/inference/Inference.scala
+++ b/src/main/scala/ai/metarank/mode/inference/Inference.scala
@@ -17,7 +17,7 @@ import cats.implicits._
 import io.findify.featury.connector.redis.RedisStore
 import io.findify.featury.values.ValueStoreConfig.RedisConfig
 import org.http4s.blaze.server.BlazeServerBuilder
-import org.apache.flink.api.scala._
+import io.findify.flinkadt.api._
 
 object Inference extends IOApp {
   import ai.metarank.mode.TypeInfos._

--- a/src/main/scala/ai/metarank/mode/inference/InferenceCmdline.scala
+++ b/src/main/scala/ai/metarank/mode/inference/InferenceCmdline.scala
@@ -71,7 +71,7 @@ object InferenceCmdline extends Logging {
   }
 
   def parse(args: List[String]): IO[InferenceCmdline] = for {
-    cmd <- IO.fromOption(OParser.parse(parser, args, InferenceCmdline(8080, "::", null, null, "", 6379, null, 1, "")))(
+    cmd <- IO.fromOption(OParser.parse(parser, args, InferenceCmdline(8080, "::", null, null, "", 6379, null, 0, "")))(
       new IllegalArgumentException("cannot parse cmdline")
     )
     _ <- IO(logger.info(s"Port: ${cmd.port}"))

--- a/src/main/scala/ai/metarank/mode/upload/Upload.scala
+++ b/src/main/scala/ai/metarank/mode/upload/Upload.scala
@@ -9,7 +9,7 @@ import io.findify.featury.flink.util.Compress
 import io.findify.featury.values.ValueStoreConfig.RedisConfig
 import org.apache.flink.core.fs.Path
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.api.scala._
+import io.findify.flinkadt.api._
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import scala.language.higherKinds
 

--- a/src/main/scala/ai/metarank/source/LocalDirSource.scala
+++ b/src/main/scala/ai/metarank/source/LocalDirSource.scala
@@ -1,12 +1,14 @@
 package ai.metarank.source
 
-import ai.metarank.model.Event
+import ai.metarank.model.{Event, Field}
+import ai.metarank.model.Event.{InteractionEvent, MetadataEvent, RankingEvent}
+import ai.metarank.util.Logging
 import better.files.File
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import io.circe.parser._
 import io.circe.syntax._
 
-case class LocalDirSource(path: String, limit: Long = Long.MaxValue) extends SourceFunction[Event] {
+case class LocalDirSource(path: String, limit: Long = Long.MaxValue) extends SourceFunction[Event] with Logging {
   @transient var stop  = false
   @transient var count = 0
   override def run(ctx: SourceFunction.SourceContext[Event]): Unit = {
@@ -17,10 +19,23 @@ case class LocalDirSource(path: String, limit: Long = Long.MaxValue) extends Sou
         for {
           file <- list
         } {
-          decode[Event](file.contentAsString) match {
+          val json = file.contentAsString
+          decode[Event](json) match {
             case Left(value) =>
+              logger.error(s"cannot decode JSON message: $json", value)
               throw value
             case Right(decoded) if count < limit =>
+              if (logger.isDebugEnabled) {
+                val eventString = decoded match {
+                  case m: MetadataEvent =>
+                    s"metadata: id=${m.item.value} fields: ${m.fields.map(formatField).mkString(" ")}"
+                  case r: RankingEvent =>
+                    s"ranking: user=${r.user.value} session=${r.session.value} fields: ${r.fields.map(formatField).mkString(" ")}"
+                  case i: InteractionEvent =>
+                    s"interaction: type=${i.`type`} rank=${i.ranking.value} user=${i.user.value} session=${i.session.value} fields: ${i.fields.map(formatField).mkString(" ")}"
+                }
+                logger.debug(s"received ${eventString}")
+              }
               file.delete()
               ctx.collect(decoded)
               count += 1
@@ -38,6 +53,14 @@ case class LocalDirSource(path: String, limit: Long = Long.MaxValue) extends Sou
 
   override def cancel(): Unit = {
     stop = true
+  }
+
+  private def formatField(field: Field) = field match {
+    case Field.StringField(name, value)     => s"$name=$value"
+    case Field.BooleanField(name, value)    => s"$name=$value"
+    case Field.NumberField(name, value)     => s"$name=$value"
+    case Field.StringListField(name, value) => s"$name=${value.mkString(",")}"
+    case Field.NumberListField(name, value) => s"$name=${value.mkString(",")}"
   }
 }
 


### PR DESCRIPTION
Stateful features were expecting to see historical state from the past. But we forgot to add savepoint-restore support for it, so after the restore all the past state was missing till someone sent a metadata update message.

Now we also store it in the savepoint.