### PR TITLE
fix race in feedback file sink-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metarank
 
-[![CI Status](https://github.com/meta-rank/metarank/workflows/Scala%20CI/badge.svg)](https://github.com/metarank/metarank/actions)
+[![CI Status](https://github.com/metarank/metarank/workflows/Scala%20CI/badge.svg)](https://github.com/metarank/metarank/actions)
 [![License: Apache 2](https://img.shields.io/badge/License-Apache2-green.svg)](https://opensource.org/licenses/Apache-2.0)
 ![Last commit](https://img.shields.io/github/last-commit/metarank/metarank)
 ![Last release](https://img.shields.io/github/release/metarank/metarank)

--- a/src/main/scala/ai/metarank/mode/inference/api/FeedbackApi.scala
+++ b/src/main/scala/ai/metarank/mode/inference/api/FeedbackApi.scala
@@ -8,12 +8,13 @@ import org.http4s._
 import org.http4s.dsl.io._
 import io.circe.syntax._
 import org.http4s.circe._
+import cats.implicits._
 
 case class FeedbackApi(writer: LocalDirWriter) {
   val routes = HttpRoutes.of[IO] { case post @ POST -> Root / "feedback" =>
     for {
       events <- post.as[Event].map(e => List(e)).handleErrorWith(_ => post.as[List[Event]])
-      _      <- IO { events.foreach(writer.write) }
+      _      <- events.map(writer.write).sequence
       ok     <- Ok("")
     } yield {
       ok

--- a/src/test/scala/ai/metarank/ingest/LocalDirSourceTest.scala
+++ b/src/test/scala/ai/metarank/ingest/LocalDirSourceTest.scala
@@ -5,22 +5,36 @@ import ai.metarank.source.LocalDirSource
 import ai.metarank.source.LocalDirSource.LocalDirWriter
 import ai.metarank.util.{FlinkTest, TestMetadataEvent}
 import better.files.File
+import cats.effect.Ref
+import cats.effect.unsafe.implicits.global
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.apache.flink.api.scala._
 
+import scala.util.Random
+
 class LocalDirSourceTest extends AnyFlatSpec with Matchers with FlinkTest {
   it should "accept events" in {
     env.setRuntimeMode(RuntimeExecutionMode.STREAMING)
     val path      = File.newTemporaryDirectory("events_").deleteOnExit()
-    val writer    = new LocalDirWriter(path)
+    val writer    = new LocalDirWriter(path, Ref.unsafe(0))
     val e1: Event = TestMetadataEvent("p1")
     val e2: Event = TestMetadataEvent("p2")
-    writer.write(e1)
-    writer.write(e2)
+    writer.write(e1).unsafeRunSync()
+    writer.write(e2).unsafeRunSync()
     val source = env.addSource(LocalDirSource(path.toString(), 1))
-    val result = source.executeAndCollect(100)
+    val result = source.executeAndCollect(1000)
     result shouldBe List(e1)
+  }
+
+  it should "not race" in {
+    val events = List.fill(1000)(TestMetadataEvent(Random.nextInt().toString))
+    val path   = File.newTemporaryDirectory("events_").deleteOnExit()
+    val writer = new LocalDirWriter(path, Ref.unsafe(0))
+    events.par.foreach(e => writer.write(e).unsafeRunSync())
+    val source = env.addSource(LocalDirSource(path.toString(), 1000))
+    val result = source.executeAndCollect(1000)
+    result.size shouldBe events.size
   }
 }


### PR DESCRIPTION
We found that calling metarank `/feedback` route in parallel in multiple threads may cause a race condition in a queue implementation between http api and flink. Here we make it work properly:
* Writer is now a Resource
* each write call is IO and multiple IOs are scheduled in a way not to break each other
* autoincremented id of event is now updated atomically.