### PR TITLE
avoid nesting resource.use

### DIFF
--- a/src/main/scala/ai/metarank/mode/inference/Inference.scala
+++ b/src/main/scala/ai/metarank/mode/inference/Inference.scala
@@ -7,7 +7,7 @@ import ai.metarank.mode.inference.ranking.LightGBMScorer
 import ai.metarank.source.LocalDirSource.LocalDirWriter
 import better.files.File
 import cats.effect.kernel.Ref
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{ExitCode, IO,Resource, IOApp}
 import org.http4s._
 import org.http4s.server._
 import org.http4s.dsl.io._
@@ -27,38 +27,33 @@ object Inference extends IOApp {
     for {
       cmd     <- InferenceCmdline.parse(args)
       config  <- Config.load(cmd.config)
-      mapping <- IO { FeatureMapping.fromFeatureSchema(config.features, config.interactions) }
-      result <- FlinkMinicluster
-        .resource()
-        .use(cluster => {
-          FeedbackFlow
-            .resource(cluster, dir.toString(), mapping, cmd)
-            .use(_ => {
-              serve(cmd, config, dir)
-            })
-        })
-    } yield {
-      result
-    }
+      mapping <- IO.pure { FeatureMapping.fromFeatureSchema(config.features, config.interactions) }
+      result <- cluster(dir,config,mapping,cmd).use {_.serve.compile.drain.as(ExitCode.Success) }
+    } yield result
   }
 
-  def serve(cmd: InferenceCmdline, config: Config, dir: File) = {
+  def cluster(dir:File,config:Config,mapping:FeatureMapping,cmd:InferenceCmdline) = {
+    for {
+      cluster <- FlinkMinicluster
+        .resource()
+       _ <- FeedbackFlow
+            .resource(cluster, dir.toString(), mapping, cmd)
+      s <- server(cmd,config,dir)
+    }  yield s
+  }
+
+  def server(cmd: InferenceCmdline, config: Config, dir: File) = {
     val store   = RedisStore(RedisConfig(cmd.redisHost, cmd.redisPort, cmd.format))
     val mapping = FeatureMapping.fromFeatureSchema(config.features, config.interactions)
     val scorer  = LightGBMScorer(cmd.model.contentAsString)
-    LocalDirWriter
+    for {
+     writer <- LocalDirWriter
       .create(dir)
-      .use(writer => {
-        val routes =
+      routes =
           HealthApi.routes <+> RankApi(mapping, store, scorer).routes <+> FeedbackApi(writer).routes
-        val httpApp = Router("/" -> routes).orNotFound
-        BlazeServerBuilder[IO]
+      httpApp = Router("/" -> routes).orNotFound
+    } yield BlazeServerBuilder[IO]
           .bindHttp(cmd.port, cmd.host)
           .withHttpApp(httpApp)
-          .serve
-          .compile
-          .drain
-          .as(ExitCode.Success)
-      })
   }
 }


### PR DESCRIPTION
Hello and thank you for interesting recommendation service!

I organized code a bit to avoid nesting `Resource#use` because nesting resources can cause leak.
Although I don't think it is the case with Inference implementation,
I think this change will prevent us from having problem finding error
caused by misuse of Resource.

> Constructing a new Resource inside the body of a Resource#use can lead to memory leaks as the outer resource is not finalized until after the inner resource is released.

https://typelevel.org/cats-effect/docs/std/hotswap

In addition, I changed `mapping <- IO {...}` to `IO.pure {...}` as
`FeatureMapping.fromFeatureSchema` does not seem to invoke IO effect or throw error.
