### PR TITLE
downgrade flink to 1.14.2 due to NPE in state api

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -7,7 +7,7 @@ object Deps {
   lazy val circeVersion     = "0.14.1"
   lazy val circeYamlVersion = "0.14.1"
   lazy val fs2Version       = "3.2.2"
-  lazy val flinkVersion     = "1.14.4"
+  lazy val flinkVersion     = "1.14.2"
   lazy val featuryVersion   = "0.3.0-M8-SNAPSHOT"
 
   val httpsDeps = Seq(

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euxo pipefail
 

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euxo pipefail
+
 JAR=$1
 TMPDIR=`mktemp -d /tmp/ranklens-XXXXXX`
 

--- a/src/main/scala/ai/metarank/mode/TypeInfos.scala
+++ b/src/main/scala/ai/metarank/mode/TypeInfos.scala
@@ -2,8 +2,9 @@ package ai.metarank.mode
 
 import ai.metarank.model.{Clickthrough, Event}
 import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, RankingEvent}
-import io.findify.featury.model.{FeatureValue, Key, Scalar, State, Write}
+import io.findify.featury.model.{FeatureValue, Key, Scalar, ScalarState, State, Write}
 import org.apache.flink.api.common.typeinfo.TypeInformation
+
 import scala.language.higherKinds
 import io.findify.flinkadt.api._
 

--- a/src/test/scala/ai/metarank/mode/BootstrapSavepointTest.scala
+++ b/src/test/scala/ai/metarank/mode/BootstrapSavepointTest.scala
@@ -1,0 +1,62 @@
+package ai.metarank.mode
+
+import ai.metarank.mode.BootstrapSavepointTest.{BootstrapFunction, Keyer}
+import ai.metarank.mode.bootstrap.Bootstrap.{FeatureValueKeySelector, StateKeySelector}
+import ai.metarank.model.FeatureScope.ItemScope
+import ai.metarank.util.FlinkTest
+import io.findify.featury.flink.FeatureJoinFunction.FeatureJoinBootstrapFunction
+import io.findify.featury.flink.{FeatureBootstrapFunction, Featury}
+import io.findify.featury.flink.format.{BulkCodec, BulkInputFormat}
+import io.findify.featury.flink.util.Compress
+import io.findify.featury.model.FeatureConfig.ScalarConfig
+import io.findify.featury.model.{FeatureConfig, FeatureValue, Key, SString, ScalarState, Schema, State, Timestamp}
+import io.findify.featury.model.Key.{FeatureName, Scope, Tag, Tenant}
+import io.findify.flinkadt.api.deriveTypeInformation
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend
+import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction
+import org.apache.flink.state.api.{OperatorTransformation, Savepoint}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.language.higherKinds
+
+class BootstrapSavepointTest extends AnyFlatSpec with Matchers {
+  it should "make savepoint" in {
+    import io.findify.flinkadt.api._
+    import org.apache.flink.DataSetOps._
+
+    val batch = ExecutionEnvironment.getExecutionEnvironment
+    batch.setParallelism(1)
+    val stateSource = batch.fromElements[(String, Int)](
+      "foo" -> 1
+    )
+
+    val transformStateless = OperatorTransformation
+      .bootstrapWith(stateSource.toJava)
+      .keyBy(Keyer, implicitly[TypeInformation[String]])
+      .transform(BootstrapFunction)
+
+    Savepoint
+      .create(new EmbeddedRocksDBStateBackend(), 32)
+      .withOperator("process-stateless-writes", transformStateless)
+      .write(s"file:///tmp/savepoint")
+
+    batch.execute("savepoint")
+
+  }
+}
+
+object BootstrapSavepointTest {
+  case object Keyer extends KeySelector[(String, Int), String] {
+    override def getKey(value: (String, Int)): String = value._1
+  }
+  case object BootstrapFunction extends KeyedStateBootstrapFunction[String, (String, Int)] {
+    override def processElement(
+        value: (String, Int),
+        ctx: KeyedStateBootstrapFunction[String, (String, Int)]#Context
+    ): Unit = {}
+  }
+}


### PR DESCRIPTION
So the NPE issue in https://github.com/metarank/metarank/issues/310 is related to some bug in flink happened in upgrade to https://github.com/metarank/metarank/pull/304. I was not able to find something related in flink's jira but in 1.15 the vulnerable part of the code was completely rewritten and has no such issue at all.

And the recent e2e test ironically made to catch this type of issue was written in bash was ignoring intermediate errors. So this PR:
* downgrades flink to 1.14.2 (snapshot of 1.15 also works, but it's not yet even RC), so NPE is gone
* e2e test is modified to handle intermediate errors (`set -e` ftw!)
* there is a reproducer test with snapshot management just in case if someone upgrades flink to 1.14.3+