### PR TITLE
do not spit job close errors on finite flink jobs

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -39,7 +39,7 @@ jobs:
       run: sbt -mem 3000 test assembly
 
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
+      uses: shogo82148/actions-setup-redis@v1
       with:
         redis-version: 6
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    timeout-minutes: 20
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -37,6 +37,11 @@ jobs:
 
     - name: Run tests
       run: sbt -mem 3000 test assembly
+
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.4.0
+      with:
+        redis-version: 6
 
     - name: Run e2e test
       run: ./run_e2e.sh target/scala-2.12/metarank.jar

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -20,10 +20,17 @@ java -jar $JAR train \
 
 echo "Training done"
 
+java -jar $JAR upload \
+  --features-dir $TMPDIR/features \
+  --host localhost \
+  --format json
+
+echo "Upload done"
+
 java -jar $JAR inference \
   --config src/test/resources/ranklens/config.yml \
   --model $TMPDIR/metarank.model \
-  --embedded-redis-features-dir $TMPDIR/features \
+  --redis-host localhost \
   --format json \
   --savepoint-dir $TMPDIR/savepoint & echo $! > $TMPDIR/inference.pid
 

--- a/src/main/scala/ai/metarank/mode/bootstrap/Bootstrap.scala
+++ b/src/main/scala/ai/metarank/mode/bootstrap/Bootstrap.scala
@@ -120,7 +120,7 @@ object Bootstrap extends IOApp with Logging {
       .write(s"${cmd.outDirUrl}/savepoint")
 
     batch.execute("savepoint")
-    logger.info("done")
+    logger.info("Bootstrap done")
   }
 
   def groupFeedback(raw: DataStream[Event]) = {

--- a/src/main/scala/ai/metarank/mode/upload/UploadCmdline.scala
+++ b/src/main/scala/ai/metarank/mode/upload/UploadCmdline.scala
@@ -62,7 +62,7 @@ object UploadCmdline extends Logging {
         )
         .withFallback(() => env.getOrElse("METARANK_FORMAT", ""))
         .validate {
-          case ""                  => Left("redis host is required")
+          case ""                  => Left("state encoding format is required")
           case "json" | "protobuf" => Right({})
           case other               => Left(s"format $other is not supported")
         }

--- a/src/test/scala/ai/metarank/mode/AsyncFlinkJobTest.scala
+++ b/src/test/scala/ai/metarank/mode/AsyncFlinkJobTest.scala
@@ -1,0 +1,23 @@
+package ai.metarank.mode
+
+import ai.metarank.mode.inference.FlinkMinicluster
+import ai.metarank.mode.upload.Upload
+import cats.effect.unsafe.implicits.global
+import org.apache.flink.configuration.Configuration
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.apache.flink.api.scala._
+
+class AsyncFlinkJobTest extends AnyFlatSpec with Matchers {
+  it should "not fail on finite jobs" in {
+    val attempt = for {
+      cluster <- FlinkMinicluster.resource(new Configuration())
+      job     <- AsyncFlinkJob.execute(cluster) { env => env.fromCollection(List(1, 2, 3)).map(x => x + 1) }
+    } yield {
+      cluster -> job
+    }
+
+    val result = attempt.use(x => Upload.blockUntilFinished(x._1, x._2))
+    result.unsafeRunSync() shouldBe {}
+  }
+}


### PR DESCRIPTION
When we run finite flink jobs within the cats.Resource, we always explicitly close it. 

The issue is when the job is finite (like the upload subtask, when there is a finite set of input files), the job successfully transitioned to a `FINISHED` state, and when we call `cluster.terminate` over a closed job, we get an error like in https://github.com/metarank/metarank/issues/310

In this PR:
* we check for the job status before terminating it, and not terminating already closed jobs
* test for finite jobs run using FlinkAsyncJobs
* e2e test updated to run a separate upload subtask and not to rely on a bundled inference one with inmem redis
* CI now has a redis container on the side