### PR TITLE
remove explicit guava dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ libraryDependencies ++= Seq(
   "com.github.blemale"   %% "scaffeine"                  % "5.1.2",
   "com.github.fppt"       % "jedis-mock"                 % "1.0.1"          % Test,
   "org.scala-lang"        % "scala-reflect"              % scalaVersion.value,
-  "com.google.guava"      % "guava"                      % "30.1.1-jre",
   "io.findify"           %% "featury-flink"              % featuryVersion,
   "io.findify"           %% "featury-redis"              % featuryVersion,
   "org.apache.flink"     %% "flink-scala"                % flinkVersion,


### PR DESCRIPTION
Flink already has transitive one, and it's always better to rely on a transitive one.