### PR TITLE
do not remove flink queue dir on errors, it should be deleted by JVM

### DIFF
--- a/src/main/scala/ai/metarank/source/LocalDirSource.scala
+++ b/src/main/scala/ai/metarank/source/LocalDirSource.scala
@@ -82,6 +82,6 @@ object LocalDirSource {
 
   object LocalDirWriter {
     def create(dir: File): Resource[IO, LocalDirWriter] =
-      effect.Resource.make(Ref.of[IO, Int](0).map(ref => new LocalDirWriter(dir, ref)))(w => IO { w.dir.delete() })
+      Resource.eval(Ref.of[IO, Int](0).map(cnt => new LocalDirWriter(dir, cnt)))
   }
 }


### PR DESCRIPTION
a fix for https://github.com/metarank/metarank/issues/367