### PR TITLE
fix bug with non-restoreable savepoint

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache.flink" level="WARN"/>
+    <logger name="org.apache.flink" level="INFO"/>
     <logger name="org.apache.flink.streaming.api.operators.collect.CollectResultFetcher" level="ERROR"/>
     <logger name="akka" level="WARN"/>
     <logger name="io.findify.featury" level="ERROR"/>

--- a/src/main/scala/ai/metarank/flow/EventProcessFunction.scala
+++ b/src/main/scala/ai/metarank/flow/EventProcessFunction.scala
@@ -3,6 +3,7 @@ package ai.metarank.flow
 import ai.metarank.FeatureMapping
 import ai.metarank.flow.FieldStore.FlinkFieldStore
 import ai.metarank.model.{Event, Field, FieldId, FieldUpdate}
+import ai.metarank.util.Logging
 import io.findify.featury.model.{Schema, State, Write}
 import org.apache.flink.api.common.state.MapStateDescriptor
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -10,12 +11,14 @@ import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction
 import org.apache.flink.util.Collector
 
 case class EventProcessFunction(desc: MapStateDescriptor[FieldId, Field], mapping: FeatureMapping)
-    extends BroadcastProcessFunction[Event, FieldUpdate, Write] {
+    extends BroadcastProcessFunction[Event, FieldUpdate, Write]
+    with Logging {
   override def processBroadcastElement(
       value: FieldUpdate,
       ctx: BroadcastProcessFunction[Event, FieldUpdate, Write]#Context,
       out: Collector[Write]
   ): Unit = {
+    logger.debug(s"field update: ${value.id}=${value.value}")
     val state = ctx.getBroadcastState(desc)
     state.put(value.id, value.value)
   }
@@ -27,6 +30,7 @@ case class EventProcessFunction(desc: MapStateDescriptor[FieldId, Field], mappin
   ): Unit = {
     val state  = FlinkFieldStore(ctx.getBroadcastState(desc))
     val writes = mapping.features.flatMap(_.writes(value, state))
+    logger.debug(s"feedback event: $value, expanded to ${writes.size} writes: $writes")
     writes.foreach(w => out.collect(w))
   }
 }

--- a/src/main/scala/ai/metarank/mode/AsyncFlinkJob.scala
+++ b/src/main/scala/ai/metarank/mode/AsyncFlinkJob.scala
@@ -20,7 +20,7 @@ object AsyncFlinkJob extends Logging {
         val env = new StreamExecutionEnvironment(new TestStreamEnvironment(cluster.cluster.getMiniCluster, 1))
         job(env)
         val graph = env.getStreamGraph.getJobGraph
-        savepoint.foreach(s => graph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(s, false)))
+        savepoint.foreach(s => graph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(s, true)))
         logger.info(s"submitted job ${graph} to local cluster")
         cluster.client.submitJob(graph)
       }

--- a/src/main/scala/ai/metarank/mode/inference/FeedbackFlow.scala
+++ b/src/main/scala/ai/metarank/mode/inference/FeedbackFlow.scala
@@ -11,33 +11,38 @@ import cats.effect.kernel.Resource
 import io.findify.featury.connector.redis.RedisStore
 import io.findify.featury.flink.format.FeatureStoreSink
 import io.findify.featury.model.FeatureValue
+import io.findify.featury.values.StoreCodec
 import io.findify.featury.values.ValueStoreConfig.RedisConfig
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings
+import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.util.TestStreamEnvironment
 
 object FeedbackFlow extends Logging {
   import ai.metarank.flow.DataStreamOps._
   def resource(
       cluster: FlinkMinicluster,
-      path: String,
       mapping: FeatureMapping,
-      cmd: InferenceCmdline,
-      redisHost: String
+      redisHost: String,
+      redisPort: Int,
+      batchSize: Int,
+      savepoint: String,
+      format: StoreCodec,
+      events: StreamExecutionEnvironment => DataStream[Event]
   )(implicit
       eti: TypeInformation[Event],
       valti: TypeInformation[FeatureValue],
       intti: TypeInformation[Int]
   ) = {
-    AsyncFlinkJob.execute(cluster, Some(cmd.savepoint)) { env =>
+    AsyncFlinkJob.execute(cluster, Some(savepoint)) { env =>
       {
-        val source          = env.addSource(new LocalDirSource(path)).id("local-source")
+        val source          = events(env).id("local-source")
         val grouped         = Bootstrap.groupFeedback(source)
         val (_, _, updates) = Bootstrap.makeUpdates(source, grouped, mapping)
         updates
           .addSink(
-            FeatureStoreSink(RedisStore(RedisConfig(redisHost, cmd.redisPort, cmd.format)), cmd.batchSize)
+            FeatureStoreSink(RedisStore(RedisConfig(redisHost, redisPort, format)), batchSize)
           )
           .id("write-redis")
       }

--- a/src/main/scala/ai/metarank/mode/inference/FlinkMinicluster.scala
+++ b/src/main/scala/ai/metarank/mode/inference/FlinkMinicluster.scala
@@ -13,7 +13,7 @@ case class FlinkMinicluster(cluster: MiniClusterWithClientResource, client: Clus
 object FlinkMinicluster {
   def resource(conf: Configuration) = Resource.make(createCluster(conf))(shutdown)
 
-  private def createCluster(conf: Configuration) = IO {
+  def createCluster(conf: Configuration) = IO {
     val cluster = new MiniClusterWithClientResource(
       new MiniClusterResourceConfiguration.Builder()
         .setNumberTaskManagers(1)
@@ -26,7 +26,7 @@ object FlinkMinicluster {
     new FlinkMinicluster(cluster, client)
   }
 
-  private def shutdown(cluster: FlinkMinicluster) = IO {
+  def shutdown(cluster: FlinkMinicluster) = IO {
     cluster.client.close()
     cluster.cluster.after()
   }

--- a/src/main/scala/ai/metarank/mode/inference/api/FeedbackApi.scala
+++ b/src/main/scala/ai/metarank/mode/inference/api/FeedbackApi.scala
@@ -2,6 +2,7 @@ package ai.metarank.mode.inference.api
 
 import ai.metarank.model.Event
 import ai.metarank.source.LocalDirSource.LocalDirWriter
+import ai.metarank.util.Logging
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import org.http4s._
@@ -10,10 +11,11 @@ import io.circe.syntax._
 import org.http4s.circe._
 import cats.implicits._
 
-case class FeedbackApi(writer: LocalDirWriter) {
+case class FeedbackApi(writer: LocalDirWriter) extends Logging {
   val routes = HttpRoutes.of[IO] { case post @ POST -> Root / "feedback" =>
     for {
       events <- post.as[Event].map(e => List(e)).handleErrorWith(_ => post.as[List[Event]])
+      _      <- IO { logger.info(s"received event $events") }
       _      <- events.map(writer.write).sequence
       ok     <- Ok("")
     } yield {

--- a/src/main/scala/ai/metarank/source/LocalDirSource.scala
+++ b/src/main/scala/ai/metarank/source/LocalDirSource.scala
@@ -15,6 +15,7 @@ case class LocalDirSource(path: String, limit: Long = Long.MaxValue) extends Sou
   @transient var stop  = false
   @transient var count = 0
   override def run(ctx: SourceFunction.SourceContext[Event]): Unit = {
+    logger.info("File-based queue main loop active")
     val dir = File(path)
     while (!stop) {
       val list = dir.listRecursively.toList.sortBy(_.name.toInt)

--- a/src/test/scala/ai/metarank/e2e/RanklensTest.scala
+++ b/src/test/scala/ai/metarank/e2e/RanklensTest.scala
@@ -107,6 +107,9 @@ class RanklensTest extends AnyFlatSpec with Matchers with FlinkTest {
       .unsafe(() => RedisStore(RedisConfig("localhost", port, StoreCodec.JsonCodec)))
       .unsafeRunSync()
 
+    val uploaded =
+      Upload.upload(s"$dir/features", "localhost", port, StoreCodec.JsonCodec, 1024).allocated.unsafeRunSync()
+
     val ranker    = RankApi(mapping, store, LtrlibScorer.fromBytes(model).unsafeRunSync())
     val response1 = ranker.rerank(ranking, true).unsafeRunSync()
     response1.state.session shouldBe empty

--- a/src/test/scala/ai/metarank/e2e/RanklensTest.scala
+++ b/src/test/scala/ai/metarank/e2e/RanklensTest.scala
@@ -3,7 +3,7 @@ package ai.metarank.e2e
 import ai.metarank.FeatureMapping
 import ai.metarank.config.Config
 import ai.metarank.e2e.RanklensTest.DiskStore
-import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, RankingEvent}
+import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, ItemRelevancy, RankingEvent}
 import ai.metarank.util.{FlinkTest, RanklensEvents}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,63 +15,123 @@ import ai.metarank.flow.DataStreamOps._
 import scala.language.higherKinds
 import ai.metarank.flow.DatasetSink
 import ai.metarank.mode.bootstrap.Bootstrap
-import ai.metarank.mode.inference.FeatureStoreResource
+import ai.metarank.mode.inference.{FeatureStoreResource, FeedbackFlow, FlinkMinicluster}
+import ai.metarank.mode.inference.RedisEndpoint.EmbeddedRedis
 import ai.metarank.mode.inference.api.RankApi
 import ai.metarank.mode.inference.ranking.LtrlibScorer
 import ai.metarank.mode.train.Train
-import ai.metarank.mode.train.TrainCmdline.LambdaMARTLightGBM
+import ai.metarank.mode.train.TrainCmdline.{LambdaMARTLightGBM, LambdaMARTXGBoost}
+import ai.metarank.mode.upload.Upload
+import ai.metarank.model.{Event, EventId}
+import ai.metarank.model.Identifier.{ItemId, SessionId, UserId}
 import better.files.{File, Resource}
+import cats.data.NonEmptyList
 import cats.effect.{IO, Ref}
 import cats.effect.unsafe.implicits.global
+import io.findify.featury.connector.redis.RedisStore
 import io.findify.featury.flink.format.BulkCodec
 import io.findify.featury.flink.util.Compress
 import io.findify.featury.model.api.{ReadRequest, ReadResponse}
-import io.findify.featury.model.{FeatureValue, Key}
-import io.findify.featury.values.FeatureStore
+import io.findify.featury.model.{FeatureValue, Key, Timestamp}
+import io.findify.featury.values.{FeatureStore, StoreCodec}
+import io.findify.featury.values.ValueStoreConfig.RedisConfig
 import org.apache.commons.io.IOUtils
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.Path
 
 import java.nio.charset.StandardCharsets
+import scala.util.Random
 
 class RanklensTest extends AnyFlatSpec with Matchers with FlinkTest {
   import ai.metarank.mode.TypeInfos._
-  val config   = Config.load(IOUtils.resourceToString("/ranklens/config.yml", StandardCharsets.UTF_8)).unsafeRunSync()
-  lazy val dir = File.newTemporaryDirectory("train_json_")
-  lazy val modelFile  = File.newTemporaryFile("model_")
-  lazy val updatesDir = File.newTemporaryDirectory("updates_")
-  val mapping         = FeatureMapping.fromFeatureSchema(config.features, config.interactions)
+  val config    = Config.load(IOUtils.resourceToString("/ranklens/config.yml", StandardCharsets.UTF_8)).unsafeRunSync()
+  lazy val dir  = File.newTemporaryDirectory("metarank_")
+  val modelFile = dir.createChild("metarank.model")
+  val mapping   = FeatureMapping.fromFeatureSchema(config.features, config.interactions)
 
   it should "accept events" in {
     env.setRuntimeMode(RuntimeExecutionMode.BATCH)
 
     val events = RanklensEvents()
 
-    val source  = env.fromCollection(events).watermark(_.timestamp.ts)
-    val grouped = Bootstrap.groupFeedback(source)
-    val updates = Bootstrap.makeUpdates(source, grouped, mapping)._3
-    Featury.writeFeatures(updates, new Path(updatesDir.toString()), Compress.NoCompression)
-    val computed = Bootstrap.joinFeatures(updates, grouped, mapping)
+    val source = env.fromCollection(events).watermark(_.timestamp.ts)
+    Bootstrap.makeBootstrap(source, mapping, dir.toString())
+    env.execute("bootstrap")
+  }
 
-    computed.sinkTo(DatasetSink.json(mapping, s"file:///$dir"))
-    env.execute()
+  it should "generate savepoint" in {
+    val batch = ExecutionEnvironment.getExecutionEnvironment
+
+    Bootstrap.makeSavepoint(batch, dir.toString, mapping)
   }
 
   // fails, see https://github.com/metarank/metarank/issues/338
-  it should "train the model" ignore {
+  it should "train the model" in {
     val dataset       = Train.loadData(dir, mapping.datasetDescriptor).unsafeRunSync()
     val (train, test) = Train.split(dataset, 80)
-    modelFile.writeByteArray(Train.trainModel(train, test, LambdaMARTLightGBM, 200))
+    modelFile.writeByteArray(Train.trainModel(train, test, LambdaMARTXGBoost, 20))
   }
 
   it should "rerank things" in {
-    val event = RanklensEvents().collect { case r: RankingEvent =>
-      r
-    }.head
-    val model    = IOUtils.toByteArray(Resource.my.getAsStream("/ranklens/ranklens.model"))
-    val store    = FeatureStoreResource.unsafe(() => DiskStore(updatesDir)).unsafeRunSync()
-    val ranker   = RankApi(mapping, store, LtrlibScorer.fromBytes(model).unsafeRunSync())
-    val response = ranker.rerank(event, false).unsafeRunSync()
-    val br       = 1
+    val ranking = RankingEvent(
+      id = EventId("event1"),
+      timestamp = Timestamp(1636993838000L),
+      user = UserId("u1"),
+      session = SessionId("s1"),
+      items = NonEmptyList.of(
+        ItemRelevancy(ItemId("7346"), 0.0),
+        ItemRelevancy(ItemId("1971"), 0.0),
+        ItemRelevancy(ItemId("69844"), 0.0),
+        ItemRelevancy(ItemId("1246"), 0.0),
+        ItemRelevancy(ItemId("3243"), 0.0),
+        ItemRelevancy(ItemId("1644"), 0.0),
+        ItemRelevancy(ItemId("6593"), 0.0),
+        ItemRelevancy(ItemId("2599"), 0.0),
+        ItemRelevancy(ItemId("3916"), 0.0)
+      )
+    )
+    val interaction = InteractionEvent(
+      id = EventId("event2"),
+      item = ItemId("69844"),
+      timestamp = Timestamp(1636993838000L),
+      user = UserId("u1"),
+      session = SessionId("s1"),
+      `type` = "click",
+      ranking = EventId("event1")
+    )
+    val port  = 1024 + Random.nextInt(10000)
+    val redis = EmbeddedRedis.createUnsafe(port)
+    val model = IOUtils.toByteArray(Resource.my.getAsStream("/ranklens/ranklens.model"))
+    val store = FeatureStoreResource
+      .unsafe(() => RedisStore(RedisConfig("localhost", port, StoreCodec.JsonCodec)))
+      .unsafeRunSync()
+
+    val ranker    = RankApi(mapping, store, LtrlibScorer.fromBytes(model).unsafeRunSync())
+    val response1 = ranker.rerank(ranking, true).unsafeRunSync()
+    response1.state.session shouldBe empty
+
+    val cluster = FlinkMinicluster.createCluster(new Configuration()).unsafeRunSync()
+    val flow = FeedbackFlow
+      .resource(
+        cluster = cluster,
+        mapping = mapping,
+        redisHost = "localhost",
+        redisPort = port,
+        batchSize = 1,
+        savepoint = s"$dir/savepoint",
+        format = StoreCodec.JsonCodec,
+        events = _.fromCollection(List[Event](ranking, interaction))
+      )
+      .allocated
+      .unsafeRunSync()
+      ._1
+    Upload.blockUntilFinished(cluster, flow).unsafeRunSync()
+
+    val response2 = ranker.rerank(ranking, true).unsafeRunSync()
+    response2.state.session should not be empty
+    response1.items.map(_.score) shouldNot be(response2.items.map(_.score))
+    redis.close()
   }
 }
 


### PR DESCRIPTION
So the inference job contained more stateful operators than the savepoint and failed to start. But we disabled flink logging, so noone noticed.