### PR TITLE
make user/session/ranking fields in event schema optional

### DIFF
--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -37,12 +37,16 @@ models:
       - genre
 
 bootstrap:
-  eventPath: file:///ranklens/events/
+  source:
+    type: file
+    path file:///ranklens/events/
   workdir: file:///tmp/bootstrap
 
 inference:
   port: 8080
   host: "0.0.0.0"
+  source:
+    type: rest
   state:
     type: redis
     host: localhost
@@ -58,16 +62,11 @@ Interaction define the way your users interact with the items you want to person
 Interactions can be used in the feature extractors, for example to calculate the click-through rate and 
 by defining `weight` you can control the optimization goal of your model: do you want to increase the amount of likes or purchases or balance between them.
 
-
 You can define interaction by `name` and set `weight` for how much this interaction affects the model: 
 
 ```yaml
-  - name: click // string
-    weight: 1.0 // floating number
+  click: 1.0
 ```
-
-The `name` of the interaction must be **unique**.
-The `name` is also used in the interaction events that are sent to Metarank and in the feature extractors.
 
 ## Event schema
 

--- a/doc/api_schema.md
+++ b/doc/api_schema.md
@@ -33,8 +33,8 @@ define which model to invoke.
 {
   "id": "81f46c34-a4bb-469c-8708-f8127cd67d27",// required
   "timestamp": "1599391467000",// required
-  "user": "user1", // required
-  "session": "session1", // required
+  "user": "user1", // optional
+  "session": "session1", // optional
   "fields": [ // optional
     {"name": "query", "value": "jeans"},
     {"name": "source", "value": "search"}
@@ -48,8 +48,8 @@ define which model to invoke.
 ```
 
 - `id`: a request identifier later used to join ranking and interaction events. This will be the same value that you will pass to feedback endpoint for impression and ranking events.
-- `user`: unique visitor identifier.
-- `session`: session identifier, a single visitor may have multiple sessions.
+- `user`: an optional unique visitor identifier.
+- `session`: an optional  session identifier, a single visitor may have multiple sessions.
 - `fields`: an optional array of extra fields that you can use in your model, for more information refer to [Supported events](event_schema.md).
 - `items`: which particular items were displayed to the visitor.
 - `items.id`: id of the content item. Should match the `item` property from item metadata event.

--- a/doc/event_schema.md
+++ b/doc/event_schema.md
@@ -93,8 +93,8 @@ This information is used by personalization algorithms to understand which items
   "event": "ranking",
   "id": "81f46c34-a4bb-469c-8708-f8127cd67d27",// required
   "timestamp": "1599391467000",// required
-  "user": "user1",// required
-  "session": "session1",// required
+  "user": "user1",// optional
+  "session": "session1",// optional
   "fields": [
       {"name": "query", "value": "cat"},
       {"name": "source", "value": "search"}
@@ -108,8 +108,8 @@ This information is used by personalization algorithms to understand which items
 ```
 
 - `id`: a request identifier later used to join ranking and interaction events. Should match the value that is sent to the [Ranking API](api_schema.md).
-- `user`: unique visitor identifier.
-- `session`: session identifier, a single visitor may have multiple sessions.
+- `user`: an optional unique visitor identifier.
+- `session`: an optional session identifier, a single visitor may have multiple sessions.
 - `fields`: an optional array of extra fields that you can use in your model, as described above.
 - `items`: which particular items were displayed to the visitor.
 - `items.id`: id of the content item. Should match the `item` property from metadata event.
@@ -128,10 +128,10 @@ The `type` field must match the `name` provided in the [Configuration](03_config
 {
   "event": "interaction",
   "id": "0f4c0036-04fb-4409-b2c6-7163a59f6b7d",// required
-  "ranking": "81f46c34-a4bb-469c-8708-f8127cd67d27", //required
+  "ranking": "81f46c34-a4bb-469c-8708-f8127cd67d27", //optional
   "timestamp": "1599391467000",// required
-  "user": "user1",// required
-  "session": "session1",// required
+  "user": "user1",// optional
+  "session": "session1",// optional
   "type": "purchase",// required
   "item": "item1",// required
   "fields": [
@@ -142,9 +142,10 @@ The `type` field must match the `name` provided in the [Configuration](03_config
 ```
 
 - `id`: a request identifier.
-- `ranking`: an identifier of the parent ranking event
-- `user`: unique visitor identifier.
-- `session`: session identifier, a single visitor may have multiple sessions.
+- `ranking`: an optional identifier of the parent ranking event. Some interactions may happen outside of the ranking event
+  (for example, likes happened on an item page), so it can be legally empty.
+- `user`: an optional unique visitor identifier.
+- `session`: an optional session identifier, a single visitor may have multiple sessions.
 - `type`: internal name of the event.
 - `item`: id of the content item. Should match the `item` property from metadata event.
 - `fields`: an optional array of extra fields that you can use in your model, as described above.

--- a/src/main/scala/ai/metarank/feature/BaseFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BaseFeature.scala
@@ -18,9 +18,9 @@ sealed trait BaseFeature {
   def keyOf(event: Event, item: Option[ItemId] = None): Option[Key] = (schema.scope, event) match {
     case (TenantScope, _) => Some(keyOf(TenantScope.scope.name, event.tenant, schema.name, event.tenant))
     case (UserScope, e: FeedbackEvent) =>
-      Some(keyOf(UserScope.scope.name, e.user.value, schema.name, event.tenant))
+      e.user.map(user => keyOf(UserScope.scope.name, user.value, schema.name, event.tenant))
     case (SessionScope, e: FeedbackEvent) =>
-      Some(keyOf(SessionScope.scope.name, e.session.value, schema.name, event.tenant))
+      e.session.map(session => keyOf(SessionScope.scope.name, session.value, schema.name, event.tenant))
     case (ItemScope, e: InteractionEvent) => Some(keyOf(ItemScope.scope.name, e.item.value, schema.name, e.tenant))
     case (ItemScope, e: ItemEvent)        => Some(keyOf(ItemScope.scope.name, e.item.value, schema.name, e.tenant))
     case (ItemScope, e: RankingEvent)     => item.map(i => keyOf(ItemScope.scope.name, i.value, schema.name, e.tenant))

--- a/src/main/scala/ai/metarank/flow/ImpressionInjectFunction.scala
+++ b/src/main/scala/ai/metarank/flow/ImpressionInjectFunction.scala
@@ -61,7 +61,7 @@ case class ImpressionInjectFunction(tpe: String, ttl: FiniteDuration)(implicit
       id = EventId(UUID.randomUUID().toString),
       item = item.id,
       timestamp = maxClick.timestamp,
-      ranking = r.id,
+      ranking = Some(r.id),
       user = r.user,
       session = r.session,
       `type` = tpe,

--- a/src/main/scala/ai/metarank/mode/bootstrap/Bootstrap.scala
+++ b/src/main/scala/ai/metarank/mode/bootstrap/Bootstrap.scala
@@ -143,7 +143,7 @@ object Bootstrap extends IOApp with Logging {
       .collect { case f: FeedbackEvent => f }
       .id("select-feedback")
       .keyingBy {
-        case int: InteractionEvent => int.ranking
+        case int: InteractionEvent => int.ranking.getOrElse(EventId("0"))
         case rank: RankingEvent    => rank.id
       }
   }

--- a/src/main/scala/ai/metarank/mode/validate/EventFileValidator.scala
+++ b/src/main/scala/ai/metarank/mode/validate/EventFileValidator.scala
@@ -70,20 +70,21 @@ object EventFileValidator extends Logging {
   }
 
   def checkUsers(ints: List[InteractionEvent], rankings: List[RankingEvent]) = {
-    val interactionUsers = ints.map(_.user.value).toSet
-    val rankingUsers     = rankings.map(_.user.value).toSet
+    val interactionUsers = ints.flatMap(_.user.map(_.value)).toSet
+    val rankingUsers     = rankings.flatMap(_.user.map(_.value)).toSet
     logger.info(s"users: interaction=${interactionUsers.size} ranking=${rankingUsers.size}")
     logger.info(s"users with no ranking: ${interactionUsers.count(x => !rankingUsers.contains(x))} (should be 0)")
   }
 
   def checkClickthroughs(ints: List[InteractionEvent], rankings: List[RankingEvent]) = {
-    val interactionIds = ints.map(_.ranking.value).toSet
+    val interactionIds = ints.flatMap(_.ranking.map(_.value)).toSet
     val rankingIds     = rankings.map(_.id.value).toSet
     logger.info(s"interactions with no ranking: ${interactionIds.count(x => !rankingIds.contains(x))} (should be 0)")
     val rankingMap = rankings.map(r => r.id.value -> r).toMap
     val interactionAfter = for {
       interaction <- ints
-      ranking     <- rankingMap.get(interaction.ranking.value) if (interaction.timestamp.isAfter(ranking.timestamp))
+      rankingId   <- interaction.ranking
+      ranking     <- rankingMap.get(rankingId.value) if (interaction.timestamp.isAfter(ranking.timestamp))
     } yield {
       interaction
     }

--- a/src/main/scala/ai/metarank/model/Event.scala
+++ b/src/main/scala/ai/metarank/model/Event.scala
@@ -37,15 +37,15 @@ object Event {
   ) extends MetadataEvent
 
   sealed trait FeedbackEvent extends Event {
-    def user: UserId
-    def session: SessionId
+    def user: Option[UserId]
+    def session: Option[SessionId]
   }
 
   case class RankingEvent(
       id: EventId,
       timestamp: Timestamp,
-      user: UserId,
-      session: SessionId,
+      user: Option[UserId] = None,
+      session: Option[SessionId] = None,
       fields: List[Field] = Nil,
       items: NonEmptyList[ItemRelevancy],
       tenant: String = "default"
@@ -55,9 +55,9 @@ object Event {
       id: EventId,
       item: ItemId,
       timestamp: Timestamp,
-      ranking: EventId,
-      user: UserId,
-      session: SessionId,
+      ranking: Option[EventId] = None,
+      user: Option[UserId] = None,
+      session: Option[SessionId] = None,
       `type`: String,
       fields: List[Field] = Nil,
       tenant: String = "default"

--- a/src/main/scala/ai/metarank/model/FeatureScope.scala
+++ b/src/main/scala/ai/metarank/model/FeatureScope.scala
@@ -43,7 +43,7 @@ object FeatureScope {
   case object UserScope extends FeatureScope {
     val scope = Scope("user")
     override def tags(event: Event): Traversable[Tag] = event match {
-      case e: FeedbackEvent => Some(Tag(scope, e.user.value))
+      case e: FeedbackEvent => e.user.map(user => Tag(scope, user.value))
       case e: UserEvent     => Some(Tag(scope, e.user.value))
       case _                => None
     }
@@ -51,7 +51,7 @@ object FeatureScope {
   case object SessionScope extends FeatureScope {
     val scope = Scope("session")
     override def tags(event: Event): Traversable[Tag] = event match {
-      case e: FeedbackEvent => Some(Tag(scope, e.session.value))
+      case e: FeedbackEvent => e.session.map(session => Tag(scope, session.value))
       case _                => None
     }
   }

--- a/src/test/scala/ai/metarank/e2e/RanklensTest.scala
+++ b/src/test/scala/ai/metarank/e2e/RanklensTest.scala
@@ -86,8 +86,8 @@ class RanklensTest extends AnyFlatSpec with Matchers with FlinkTest {
     val ranking = RankingEvent(
       id = EventId("event1"),
       timestamp = Timestamp(1636993838000L),
-      user = UserId("u1"),
-      session = SessionId("s1"),
+      user = Some(UserId("u1")),
+      session = Some(SessionId("s1")),
       items = NonEmptyList.of(
         ItemRelevancy(ItemId("7346"), 0.0),
         ItemRelevancy(ItemId("1971"), 0.0),
@@ -104,10 +104,10 @@ class RanklensTest extends AnyFlatSpec with Matchers with FlinkTest {
       id = EventId("event2"),
       item = ItemId("69844"),
       timestamp = Timestamp(1636993838000L),
-      user = UserId("u1"),
-      session = SessionId("s1"),
+      user = Some(UserId("u1")),
+      session = Some(SessionId("s1")),
       `type` = "click",
-      ranking = EventId("event1")
+      ranking = Some(EventId("event1"))
     )
     val port  = 1024 + Random.nextInt(10000)
     val redis = EmbeddedRedis.createUnsafe(port)

--- a/src/test/scala/ai/metarank/feature/InteractedWithFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/InteractedWithFeatureTest.scala
@@ -73,7 +73,7 @@ class InteractedWithFeatureTest extends AnyFlatSpec with Matchers with FeatureTe
   it should "emit bounded list appends" in {
     val writes1 =
       feature.writes(
-        TestInteractionEvent("p1", "i1", Nil).copy(session = SessionId("s1"), `type` = "impression"),
+        TestInteractionEvent("p1", "i1", Nil).copy(session = Some(SessionId("s1")), `type` = "impression"),
         FieldStore.map(
           Map(ItemFieldId(Tenant("default"), ItemId("p1"), "color") -> StringField("color", "red"))
         )
@@ -101,7 +101,7 @@ class InteractedWithFeatureTest extends AnyFlatSpec with Matchers with FeatureTe
       itemKey3 -> ScalarValue(itemKey3, Timestamp.now, SString("green")),
       sesKey   -> BoundedListValue(sesKey, Timestamp.now, List(TimeValue(Timestamp.now, SString("red"))))
     )
-    val request = TestRankingEvent(List("p1", "p2", "p3")).copy(session = SessionId("s1"))
+    val request = TestRankingEvent(List("p1", "p2", "p3")).copy(session = Some(SessionId("s1")))
 
     val values2 = feature.value(
       request = request,

--- a/src/test/scala/ai/metarank/feature/InteractionCountTest.scala
+++ b/src/test/scala/ai/metarank/feature/InteractionCountTest.scala
@@ -35,8 +35,9 @@ class InteractionCountTest extends AnyFlatSpec with Matchers with FeatureTest {
   }
 
   it should "also increment on session key" in {
-    val sf    = InteractionCountFeature(feature.schema.copy(scope = SessionScope))
-    val event = TestInteractionEvent("e1", "e0").copy(`type` = "click", item = ItemId("p1"), session = SessionId("s1"))
+    val sf = InteractionCountFeature(feature.schema.copy(scope = SessionScope))
+    val event =
+      TestInteractionEvent("e1", "e0").copy(`type` = "click", item = ItemId("p1"), session = Some(SessionId("s1")))
     val write = sf.writes(event, FieldStore.empty)
     write shouldBe List(
       Increment(Key(Tag(SessionScope.scope, "s1"), FeatureName("cnt"), Tenant("default")), event.timestamp, 1)

--- a/src/test/scala/ai/metarank/feature/StringFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/StringFeatureTest.scala
@@ -73,12 +73,12 @@ class StringFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       )
     )
     val event =
-      TestInteractionEvent("p1", "p0").copy(session = SessionId("s1"), fields = List(StringField("country", "b")))
+      TestInteractionEvent("p1", "p0").copy(session = Some(SessionId("s1")), fields = List(StringField("country", "b")))
     val write = feature.writes(event, FieldStore.empty)
     val key   = Key(feature.states.head, Tenant("default"), "s1")
     write shouldBe List(Put(key, event.timestamp, SStringList(List("b"))))
     val value = feature.value(
-      request = TestRankingEvent(List("p1")).copy(session = SessionId("s1")),
+      request = TestRankingEvent(List("p1")).copy(session = Some(SessionId("s1"))),
       features = Map(key -> ScalarValue(key, Timestamp.now, SStringList(List("b")))),
       id = ItemRelevancy(ItemId("p1"))
     )

--- a/src/test/scala/ai/metarank/feature/UserAgentFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/UserAgentFeatureTest.scala
@@ -32,7 +32,7 @@ class UserAgentFeatureTest extends AnyFlatSpec with Matchers {
     val value = feature.value(
       request = TestRankingEvent(List("p1")).copy(
         fields = List(StringField("ua", "Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1)")),
-        session = SessionId("s1"),
+        session = Some(SessionId("s1")),
         timestamp = now
       ),
       features = Map.empty
@@ -47,7 +47,7 @@ class UserAgentFeatureTest extends AnyFlatSpec with Matchers {
     val k = Key(Tag(SessionScope.scope, "s1"), FeatureName("ua_platform"), Tenant("default"))
     val value = feature.value(
       request = TestRankingEvent(List("p1")).copy(
-        session = SessionId("s1"),
+        session = Some(SessionId("s1")),
         timestamp = now,
         fields = List(StringField("ua", "Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1)"))
       ),

--- a/src/test/scala/ai/metarank/flow/ClickthroughJoinFunctionTest.scala
+++ b/src/test/scala/ai/metarank/flow/ClickthroughJoinFunctionTest.scala
@@ -21,10 +21,10 @@ class ClickthroughJoinFunctionTest extends AnyFlatSpec with Matchers with FlinkT
       )
       .watermark(_.timestamp.ts)
       .keyingBy {
-        case i: InteractionEvent => i.ranking
+        case i: InteractionEvent => i.ranking.getOrElse(EventId("0"))
         case r: RankingEvent     => r.id
       }
-      .process(new ClickthroughJoinFunction())
+      .process(ClickthroughJoinFunction())
       .executeAndCollect(10)
     result.map(_.ranking.id.value) shouldBe List("1")
     result.flatMap(_.ranking.items.toList.map(_.id.value)) shouldBe List("p1", "p2", "p3")

--- a/src/test/scala/ai/metarank/flow/ImpressionInjectFunctionTest.scala
+++ b/src/test/scala/ai/metarank/flow/ImpressionInjectFunctionTest.scala
@@ -19,7 +19,7 @@ class ImpressionInjectFunctionTest extends AnyFlatSpec with Matchers with FlinkT
       )
       .keyBy(e =>
         e match {
-          case int: InteractionEvent => int.ranking
+          case int: InteractionEvent => int.ranking.getOrElse(EventId("0"))
           case rank: RankingEvent    => rank.id
         }
       )

--- a/src/test/scala/ai/metarank/model/EventJsonTest.scala
+++ b/src/test/scala/ai/metarank/model/EventJsonTest.scala
@@ -136,8 +136,8 @@ class EventJsonTest extends AnyFlatSpec with Matchers {
       RankingEvent(
         id = EventId("81f46c34-a4bb-469c-8708-f8127cd67d27"),
         timestamp = Timestamp(1599391467000L),
-        user = UserId("user1"),
-        session = SessionId("session1"),
+        user = Some(UserId("user1")),
+        session = Some(SessionId("session1")),
         fields = List(
           StringField("query", "jeans"),
           StringField("source", "search")
@@ -146,6 +146,30 @@ class EventJsonTest extends AnyFlatSpec with Matchers {
           ItemRelevancy(ItemId("product3"), 2.0),
           ItemRelevancy(ItemId("product1"), 1.0),
           ItemRelevancy(ItemId("product2"), 0.5)
+        ),
+        tenant = "default"
+      )
+    )
+  }
+  it should "decode ranking with no user/session" in {
+    val json = """{
+                 |  "event": "ranking",
+                 |  "id": "81f46c34-a4bb-469c-8708-f8127cd67d27",
+                 |  "timestamp": "1599391467000",
+                 |  "items": [
+                 |    {"id": "product3"}
+                 |  ]
+                 |}
+                 |""".stripMargin
+    decode[Event](json) shouldBe Right(
+      RankingEvent(
+        id = EventId("81f46c34-a4bb-469c-8708-f8127cd67d27"),
+        timestamp = Timestamp(1599391467000L),
+        user = None,
+        session = None,
+        fields = Nil,
+        items = NonEmptyList.of(
+          ItemRelevancy(ItemId("product3"), None)
         ),
         tenant = "default"
       )
@@ -170,10 +194,40 @@ class EventJsonTest extends AnyFlatSpec with Matchers {
     decode[Event](json) shouldBe Right(
       InteractionEvent(
         id = EventId("0f4c0036-04fb-4409-b2c6-7163a59f6b7d"),
-        ranking = EventId("81f46c34-a4bb-469c-8708-f8127cd67d27"),
+        ranking = Some(EventId("81f46c34-a4bb-469c-8708-f8127cd67d27")),
         timestamp = Timestamp(1599391467000L),
-        user = UserId("user1"),
-        session = SessionId("session1"),
+        user = Some(UserId("user1")),
+        session = Some(SessionId("session1")),
+        `type` = "purchase",
+        item = ItemId("product1"),
+        fields = List(
+          NumberField("count", 2),
+          StringField("shipping", "DHL")
+        ),
+        tenant = "default"
+      )
+    )
+  }
+
+  it should "decode interactions with no user/session/ranking" in {
+    val json = """{
+                 |  "event": "interaction",
+                 |  "id": "0f4c0036-04fb-4409-b2c6-7163a59f6b7d",
+                 |  "timestamp": "1599391467000",
+                 |  "type": "purchase",
+                 |  "item": "product1",
+                 |  "fields": [
+                 |    {"name": "count", "value": 2},
+                 |    {"name": "shipping", "value": "DHL"}
+                 |  ]
+                 |}""".stripMargin
+    decode[Event](json) shouldBe Right(
+      InteractionEvent(
+        id = EventId("0f4c0036-04fb-4409-b2c6-7163a59f6b7d"),
+        ranking = None,
+        timestamp = Timestamp(1599391467000L),
+        user = None,
+        session = None,
         `type` = "purchase",
         item = ItemId("product1"),
         fields = List(

--- a/src/test/scala/ai/metarank/util/RanklensDatasetGenerator.scala
+++ b/src/test/scala/ai/metarank/util/RanklensDatasetGenerator.scala
@@ -120,8 +120,8 @@ object RanklensDatasetGenerator {
         RankingEvent(
           id = id,
           timestamp = ts,
-          user = UserId(t.user),
-          session = SessionId(t.user),
+          user = Some(UserId(t.user)),
+          session = Some(SessionId(t.user)),
           fields = Nil,
           items = NonEmptyList.fromListUnsafe(t.shown).map(id => ItemRelevancy(ItemId(id.toString), 0)),
           tenant = "default"
@@ -131,11 +131,11 @@ object RanklensDatasetGenerator {
         InteractionEvent(
           id = EventId(UUID.randomUUID().toString),
           timestamp = ts.plus(5.second),
-          user = UserId(t.user),
-          session = SessionId(t.user),
+          user = Some(UserId(t.user)),
+          session = Some(SessionId(t.user)),
           fields = Nil,
           item = ItemId(item.toString),
-          ranking = id,
+          ranking = Some(id),
           `type` = "click",
           tenant = "default"
         )

--- a/src/test/scala/ai/metarank/util/TestInteractionEvent.scala
+++ b/src/test/scala/ai/metarank/util/TestInteractionEvent.scala
@@ -11,11 +11,11 @@ object TestInteractionEvent {
   def apply(item: String, parent: String, fields: List[Field] = Nil) = InteractionEvent(
     id = EventId(UUID.randomUUID().toString),
     timestamp = Timestamp.now,
-    user = UserId("u1"),
-    session = SessionId("s1"),
+    user = Some(UserId("u1")),
+    session = Some(SessionId("s1")),
     fields = fields,
     item = ItemId(item),
-    ranking = EventId(parent),
+    ranking = Some(EventId(parent)),
     `type` = "click",
     tenant = "default"
   )

--- a/src/test/scala/ai/metarank/util/TestRankingEvent.scala
+++ b/src/test/scala/ai/metarank/util/TestRankingEvent.scala
@@ -12,8 +12,8 @@ object TestRankingEvent {
   def apply(items: List[String]) = RankingEvent(
     id = EventId(UUID.randomUUID().toString),
     timestamp = Timestamp.now,
-    user = UserId("u1"),
-    session = SessionId("s1"),
+    user = Some(UserId("u1")),
+    session = Some(SessionId("s1")),
     fields = Nil,
     items = NonEmptyList.fromListUnsafe(items).map(item => ItemRelevancy(ItemId(item), 1.0)),
     tenant = "default"


### PR DESCRIPTION
Fixes https://github.com/metarank/metarank/issues/415 and https://github.com/metarank/metarank/issues/414