### PR TITLE
Bootstrap performance work

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,7 +8,7 @@ object Deps {
   lazy val circeYamlVersion = "0.14.1"
   lazy val fs2Version       = "3.2.2"
   lazy val flinkVersion     = "1.15.0"
-  lazy val featuryVersion   = "0.3.0-M12-SNAPSHOT"
+  lazy val featuryVersion   = "0.3.0-M14-SNAPSHOT"
   lazy val luceneVersion    = "9.1.0"
 
   val httpsDeps = Seq(

--- a/src/main/scala/ai/metarank/flow/EventProcessFunction.scala
+++ b/src/main/scala/ai/metarank/flow/EventProcessFunction.scala
@@ -18,7 +18,7 @@ case class EventProcessFunction(desc: MapStateDescriptor[FieldId, Field], mappin
       ctx: BroadcastProcessFunction[Event, FieldUpdate, Write]#Context,
       out: Collector[Write]
   ): Unit = {
-    logger.debug(s"field update: ${value.id}=${value.value}")
+    // logger.debug(s"field update: ${value.id}=${value.value}")
     val state = ctx.getBroadcastState(desc)
     state.put(value.id, value.value)
   }
@@ -30,7 +30,7 @@ case class EventProcessFunction(desc: MapStateDescriptor[FieldId, Field], mappin
   ): Unit = {
     val state  = FlinkFieldStore(ctx.getBroadcastState(desc))
     val writes = mapping.features.flatMap(_.writes(value, state))
-    logger.debug(s"feedback event: $value, expanded to ${writes.size} writes: $writes")
+    // logger.debug(s"feedback event: $value, expanded to ${writes.size} writes: $writes")
     writes.foreach(w => out.collect(w))
   }
 }

--- a/src/main/scala/ai/metarank/mode/inference/Inference.scala
+++ b/src/main/scala/ai/metarank/mode/inference/Inference.scala
@@ -26,7 +26,7 @@ import io.findify.featury.values.FeatureStore
 import io.findify.featury.values.ValueStoreConfig.RedisConfig
 import org.http4s.blaze.server.BlazeServerBuilder
 import io.findify.flinkadt.api._
-
+import scala.concurrent.duration._
 import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters._
 
@@ -65,7 +65,8 @@ object Inference extends IOApp with Logging {
         config.bootstrap.workdir.child("savepoint"),
         config.inference.state.format,
         config.bootstrap.syntheticImpression,
-        source.eventStream(_, bounded = false)
+        source.eventStream(_, bounded = false),
+        batchPeriod = 100.millis
       )
       store <- FeatureStoreResource.make(() =>
         RedisStore(RedisConfig(config.inference.state.host, config.inference.state.port, config.inference.state.format))

--- a/src/main/scala/ai/metarank/mode/inference/RedisEndpoint.scala
+++ b/src/main/scala/ai/metarank/mode/inference/RedisEndpoint.scala
@@ -7,6 +7,7 @@ import cats.effect.IO
 import cats.effect.kernel.Resource
 import com.github.microwww.redis.RedisServer
 import io.findify.featury.values.StoreCodec
+import scala.concurrent.duration._
 
 sealed trait RedisEndpoint {
   def host: String
@@ -22,7 +23,7 @@ object RedisEndpoint {
 
   case class EmbeddedRedis(host: String, port: Int, format: StoreCodec, service: RedisServer, dir: MPath)
       extends RedisEndpoint {
-    override def upload: IO[Unit] = Upload.upload(dir, host, port, format).use(_ => IO.unit)
+    override def upload: IO[Unit] = Upload.upload(dir, host, port, format, 100.millis).use(_ => IO.unit)
 
     override def close: IO[Unit] = IO { service.close() }
   }

--- a/src/main/scala/ai/metarank/mode/upload/WindowBatchFunction.scala
+++ b/src/main/scala/ai/metarank/mode/upload/WindowBatchFunction.scala
@@ -1,0 +1,59 @@
+package ai.metarank.mode.upload
+
+import ai.metarank.util.Logging
+import io.findify.featury.model.Key.Tenant
+import io.findify.featury.model.{FeatureValue, Timestamp}
+import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
+import org.apache.flink.util.Collector
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+case class WindowBatchFunction(period: FiniteDuration, size: Int)
+    extends KeyedProcessFunction[Tenant, FeatureValue, List[FeatureValue]]
+    with Logging {
+
+  val buffer    = mutable.Buffer[FeatureValue]()
+  var lastFlush = 0L
+  var timerSet  = false
+
+  override def processElement(
+      value: FeatureValue,
+      ctx: KeyedProcessFunction[Tenant, FeatureValue, List[FeatureValue]]#Context,
+      out: Collector[List[FeatureValue]]
+  ): Unit = {
+    val now = ctx.timerService().currentProcessingTime()
+    buffer.addOne(value)
+    if ((buffer.length >= size) || (now - lastFlush >= period.toMillis)) {
+      logger.info(s"flushed buffer of ${buffer.size} events (on size)")
+      flush(now, out)
+    }
+    if (!timerSet && (period != 0.seconds)) {
+      ctx.timerService().registerProcessingTimeTimer(now + period.toMillis)
+      timerSet = true
+    }
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: KeyedProcessFunction[Tenant, FeatureValue, List[FeatureValue]]#OnTimerContext,
+      out: Collector[List[FeatureValue]]
+  ): Unit = {
+    val now = ctx.timerService().currentProcessingTime()
+    flush(now, out)
+    logger.info(s"flushed buffer of ${buffer.size} events (on timer)")
+    ctx.timerService().registerProcessingTimeTimer(now + period.toMillis)
+  }
+
+  override def close(): Unit = {
+    logger.info(s"closed: buffer=${buffer.size}")
+  }
+
+  def flush(now: Long, out: Collector[List[FeatureValue]]) = {
+    if (buffer.nonEmpty) {
+      out.collect(buffer.toList)
+      buffer.clear()
+    }
+    lastFlush = now
+  }
+}

--- a/src/main/scala/ai/metarank/source/FeatureValueWatermarkStrategy.scala
+++ b/src/main/scala/ai/metarank/source/FeatureValueWatermarkStrategy.scala
@@ -1,0 +1,32 @@
+package ai.metarank.source
+
+import ai.metarank.source.FeatureValueWatermarkStrategy.FeatureValueTimeAssigner
+import io.findify.featury.model.FeatureValue
+import org.apache.flink.api.common.eventtime.{
+  BoundedOutOfOrdernessWatermarks,
+  SerializableTimestampAssigner,
+  TimestampAssigner,
+  TimestampAssignerSupplier,
+  WatermarkGenerator,
+  WatermarkGeneratorSupplier,
+  WatermarkStrategy
+}
+
+import java.time.Duration
+
+case class FeatureValueWatermarkStrategy(maxOutOfOrder: Duration) extends WatermarkStrategy[FeatureValue] {
+  override def createWatermarkGenerator(context: WatermarkGeneratorSupplier.Context): WatermarkGenerator[FeatureValue] =
+    new BoundedOutOfOrdernessWatermarks[FeatureValue](maxOutOfOrder)
+
+  override def createTimestampAssigner(context: TimestampAssignerSupplier.Context): TimestampAssigner[FeatureValue] =
+    new FeatureValueTimeAssigner()
+}
+
+object FeatureValueWatermarkStrategy {
+  def apply(jitterSeconds: Int = 20) = new FeatureValueWatermarkStrategy(Duration.ofSeconds(jitterSeconds))
+
+  class FeatureValueTimeAssigner extends SerializableTimestampAssigner[FeatureValue] {
+    override def extractTimestamp(element: FeatureValue, recordTimestamp: Long): Long = element.ts.ts
+  }
+
+}

--- a/src/test/resources/ranklens/config.yml
+++ b/src/test/resources/ranklens/config.yml
@@ -12,7 +12,7 @@ inference:
   state:
     type: redis
     host: localhost
-    format: json
+    format: protobuf
 
 models:
 #  lightgbm:

--- a/src/test/scala/ai/metarank/api/RankApiTest.scala
+++ b/src/test/scala/ai/metarank/api/RankApiTest.scala
@@ -62,8 +62,10 @@ class RankApiTest extends AnyFlatSpec with Matchers {
 object RankApiTest {
   class BrokenStore extends FeatureStore {
     override def read(request: ReadRequest): IO[ReadResponse] = IO.raiseError(StateReadError("oops"))
+    override def writeSync(batch: List[FeatureValue]): Unit   = ???
     override def write(batch: List[FeatureValue]): IO[Unit]   = IO.raiseError(StateReadError("oops"))
     override def close(): IO[Unit]                            = IO.raiseError(StateReadError("oops"))
+    override def closeSync(): Unit                            = ???
   }
 
   class CountingStore extends FeatureStore {
@@ -75,9 +77,13 @@ object RankApiTest {
       featureReads += request.keys.size
       ReadResponse(Nil)
     }
-    override def write(batch: List[FeatureValue]): IO[Unit] = IO {
+    override def write(batch: List[FeatureValue]): IO[Unit] = IO { writeSync(batch) }
+
+    override def writeSync(batch: List[FeatureValue]): Unit = {
       writes += 1
     }
     override def close(): IO[Unit] = IO.unit
+
+    override def closeSync(): Unit = {}
   }
 }

--- a/src/test/scala/ai/metarank/mode/FieldUpdateCodecTest.scala
+++ b/src/test/scala/ai/metarank/mode/FieldUpdateCodecTest.scala
@@ -11,7 +11,8 @@ import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import java.io.ByteArrayInputStream
+
+import java.io.{BufferedInputStream, ByteArrayInputStream}
 
 class FieldUpdateCodecTest extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
   it should "not fail on EOF" in {
@@ -86,7 +87,7 @@ class FieldUpdateCodecTest extends AnyFlatSpec with Matchers with ScalaCheckProp
       {
         val out = new ByteArrayOutputStream()
         FieldUpdateCodec.write(update, out)
-        val decoded = FieldUpdateCodec.read(new ByteArrayInputStream(out.toByteArray))
+        val decoded = FieldUpdateCodec.read(new BufferedInputStream(new ByteArrayInputStream(out.toByteArray), 10))
         decoded shouldBe Some(update)
       }
     }

--- a/src/test/scala/ai/metarank/util/FlinkTest.scala
+++ b/src/test/scala/ai/metarank/util/FlinkTest.scala
@@ -14,6 +14,7 @@ object FlinkTest {
     e.setParallelism(1)
     e.setRestartStrategy(RestartStrategies.noRestart())
     e.setStateBackend(new EmbeddedRocksDBStateBackend())
+    e.getConfig.enableObjectReuse()
     e
   }
 }

--- a/src/test/scala/ai/metarank/util/RandomFeatureStore.scala
+++ b/src/test/scala/ai/metarank/util/RandomFeatureStore.scala
@@ -34,6 +34,8 @@ case class RandomFeatureStore(mapping: FeatureMapping, seed: Int = 0) extends Fe
   val random                                              = new Random(seed)
   override def write(batch: List[FeatureValue]): IO[Unit] = IO.unit
 
+  override def writeSync(batch: List[FeatureValue]): Unit = {}
+
   override def read(request: ReadRequest): IO[ReadResponse] = IO {
     val values: List[FeatureValue] = for {
       key     <- request.keys
@@ -53,5 +55,8 @@ case class RandomFeatureStore(mapping: FeatureMapping, seed: Int = 0) extends Fe
     ReadResponse(values)
   }
 
-  override def close(): IO[Unit] = ???
+  override def close(): IO[Unit] = IO.unit
+
+  override def closeSync(): Unit = {}
+
 }


### PR DESCRIPTION
This thing improves bootstrap performance a lot:
* we only store the latest field/feature/state entries (and not the full changelog): smaller bootstrap size (10x on ranklens)
* redis writer now has proper batching support
* xgboost/lightgbm dataset export now uses buffering and writes data in chunks
* fields for some reason were not part of the savepoint: now they are