### PR TITLE
fix issue with crash on single-bucket window counters

### DIFF
--- a/src/main/scala/ai/metarank/FeatureMapping.scala
+++ b/src/main/scala/ai/metarank/FeatureMapping.scala
@@ -20,7 +20,7 @@ import ai.metarank.feature.WordCountFeature.WordCountSchema
 import ai.metarank.feature._
 import ai.metarank.model.Event.RankingEvent
 import ai.metarank.model.Key.FeatureName
-import ai.metarank.model.{FeatureSchema, FieldName, Key, MValue, Schema, ScopeType}
+import ai.metarank.model.{Dimension, FeatureSchema, FieldName, Key, MValue, Schema, ScopeType}
 import ai.metarank.rank.{LambdaMARTModel, Model, NoopModel, ShuffleModel}
 import ai.metarank.util.Logging
 import cats.data.{NonEmptyList, NonEmptyMap}
@@ -107,8 +107,11 @@ object FeatureMapping extends Logging {
   def makeDatasetDescriptor(features: List[BaseFeature]): DatasetDescriptor = {
     val datasetFeatures = features.map {
       case f: StringFeature if f.schema.encode == IndexEncoderName => CategoryFeature(f.schema.name.value)
-      case f: BaseFeature if f.dim == 1                            => SingularFeature(f.schema.name.value)
-      case f: BaseFeature                                          => VectorFeature(f.schema.name.value, f.dim)
+      case f: BaseFeature =>
+        f.dim match {
+          case Dimension.VectorDim(dim) => VectorFeature(f.schema.name.value, dim)
+          case Dimension.SingleDim      => SingularFeature(f.schema.name.value)
+        }
     }
     DatasetDescriptor(datasetFeatures)
   }

--- a/src/main/scala/ai/metarank/feature/BaseFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BaseFeature.scala
@@ -6,11 +6,11 @@ import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Identifier.ItemId
 import ai.metarank.model.Scope.{GlobalScope, ItemScope, SessionScope, UserScope}
 import ai.metarank.model.ScopeType.{GlobalScopeType, ItemScopeType, SessionScopeType, UserScopeType}
-import ai.metarank.model.{Event, FeatureSchema, FeatureValue, FieldName, Key, MValue, ScopeType, Write}
+import ai.metarank.model.{Dimension, Event, FeatureSchema, FeatureValue, FieldName, Key, MValue, ScopeType, Write}
 import cats.effect.IO
 
 sealed trait BaseFeature {
-  def dim: Int
+  def dim: Dimension
   def schema: FeatureSchema
   def states: List[FeatureConfig]
   def writes(event: Event, features: Persistence): IO[Iterable[Write]]

--- a/src/main/scala/ai/metarank/feature/BooleanFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BooleanFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BooleanFeature.BooleanFeatureSchema
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.ItemRelevancy
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
@@ -22,7 +23,7 @@ import scala.concurrent.duration._
 import shapeless.syntax.typeable._
 
 case class BooleanFeature(schema: BooleanFeatureSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = ScalarConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
+++ b/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
@@ -4,6 +4,7 @@ import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.FieldMatchFeature.FieldMatchSchema
 import ai.metarank.feature.matcher.{FieldMatcher, NgramMatcher}
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
 import ai.metarank.model.FeatureValue.ScalarValue
@@ -24,7 +25,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import scala.concurrent.duration._
 
 case class FieldMatchFeature(schema: FieldMatchSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = ScalarConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/InteractedWithFeature.scala
+++ b/src/main/scala/ai/metarank/feature/InteractedWithFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.InteractedWithFeature.InteractedWithSchema
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, ItemEvent, ItemRelevancy}
 import ai.metarank.model.Feature.BoundedListFeature.BoundedListConfig
 import ai.metarank.model.Feature.FeatureConfig
@@ -39,7 +40,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
 case class InteractedWithFeature(schema: InteractedWithSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   // stores last interactions of customer
   val lastValues = BoundedListConfig(

--- a/src/main/scala/ai/metarank/feature/InteractionCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/InteractionCountFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.InteractionCountFeature.InteractionCountSchema
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.ItemRelevancy
 import ai.metarank.model.Feature.CounterFeature.CounterConfig
 import ai.metarank.model.Feature.FeatureConfig
@@ -15,10 +16,11 @@ import ai.metarank.util.Logging
 import cats.effect.IO
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+
 import scala.concurrent.duration._
 
 case class InteractionCountFeature(schema: InteractionCountSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = CounterConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/ItemAgeFeature.scala
+++ b/src/main/scala/ai/metarank/feature/ItemAgeFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.ItemAgeFeature.ItemAgeSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.{ItemRelevancy, eventCodec}
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
@@ -26,7 +27,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 case class ItemAgeFeature(schema: ItemAgeSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = ScalarConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/LocalDateTimeFeature.scala
+++ b/src/main/scala/ai/metarank/feature/LocalDateTimeFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.RankingFeature
 import ai.metarank.feature.LocalDateTimeFeature.LocalDateTimeSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Field.StringField
 import ai.metarank.model.FieldName.EventType
@@ -21,7 +22,7 @@ import java.time.{Duration, ZonedDateTime}
 import scala.util.{Failure, Success, Try}
 
 case class LocalDateTimeFeature(schema: LocalDateTimeSchema) extends RankingFeature with Logging {
-  override def dim: Int                                                     = 1
+  override def dim                                                          = SingleDim
   override def states: List[FeatureConfig]                                  = Nil
   override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO.pure(Nil)
 

--- a/src/main/scala/ai/metarank/feature/NumberFeature.scala
+++ b/src/main/scala/ai/metarank/feature/NumberFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.NumberFeature.NumberFeatureSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.ItemRelevancy
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
@@ -21,7 +22,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import scala.concurrent.duration._
 
 case class NumberFeature(schema: NumberFeatureSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = ScalarConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/RateFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RateFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.RateFeature.RateFeatureSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.VectorDim
 import ai.metarank.model.Event.{InteractionEvent, ItemRelevancy}
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.PeriodicCounterFeature.{PeriodRange, PeriodicCounterConfig}
@@ -21,7 +22,7 @@ import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
 case class RateFeature(schema: RateFeatureSchema) extends ItemFeature {
-  override val dim: Int = schema.periods.size
+  override val dim = VectorDim(schema.periods.size)
 
   val top = PeriodicCounterConfig(
     scope = schema.scope,
@@ -74,8 +75,8 @@ case class RateFeature(schema: RateFeatureSchema) extends ItemFeature {
     val result = for {
       topValue    <- features.get(Key(ItemScope(id.id), top.name))
       bottomValue <- features.get(Key(ItemScope(id.id), bottom.name))
-      topNum      <- topValue.cast[PeriodicCounterValue] if topNum.values.size == dim
-      bottomNum   <- bottomValue.cast[PeriodicCounterValue] if (bottomNum.values.size == dim)
+      topNum      <- topValue.cast[PeriodicCounterValue] if topNum.values.size == dim.dim
+      bottomNum   <- bottomValue.cast[PeriodicCounterValue] if bottomNum.values.size == dim.dim
     } yield {
       val values = topNum.values.zip(bottomNum.values).map(x => x._1.value / x._2.value.toDouble).toArray
       VectorValue(schema.name, values, dim)

--- a/src/main/scala/ai/metarank/feature/RefererFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RefererFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.RankingFeature
 import ai.metarank.feature.RefererFeature.RefererSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.{FeedbackEvent, InteractionEvent, RankingEvent, UserEvent}
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
@@ -61,7 +62,7 @@ case class RefererFeature(schema: RefererSchema) extends RankingFeature with Log
     PaidMedium.value     -> 5
   )
 
-  override val dim: Int = 1
+  override val dim = SingleDim
 
   override val states: List[FeatureConfig] = List(conf)
 

--- a/src/main/scala/ai/metarank/feature/RelevancyFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RelevancyFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.RelevancyFeature.RelevancySchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.ItemRelevancy
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Key.FeatureName
@@ -17,7 +18,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import scala.concurrent.duration.FiniteDuration
 
 case class RelevancyFeature(schema: RelevancySchema) extends ItemFeature {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   override def states: List[FeatureConfig] = Nil
 

--- a/src/main/scala/ai/metarank/feature/UserAgentFeature.scala
+++ b/src/main/scala/ai/metarank/feature/UserAgentFeature.scala
@@ -4,6 +4,7 @@ import ai.metarank.feature.BaseFeature.RankingFeature
 import ai.metarank.feature.UserAgentFeature.UserAgentSchema
 import ai.metarank.feature.ua.{BotField, BrowserField, OSField, PlatformField}
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.VectorDim
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
 import ai.metarank.model.FeatureValue.ScalarValue
@@ -25,8 +26,8 @@ import ua_parser.{Client, Parser}
 import scala.concurrent.duration._
 
 case class UserAgentFeature(schema: UserAgentSchema) extends RankingFeature {
-  lazy val parser       = new Parser()
-  override def dim: Int = schema.field.dim
+  lazy val parser  = new Parser()
+  override def dim = schema.field.dim
 
   val conf = ScalarConfig(
     scope = SessionScopeType,
@@ -56,9 +57,9 @@ case class UserAgentFeature(schema: UserAgentSchema) extends RankingFeature {
   ): MValue = {
     request.session.flatMap(session => features.get(Key(SessionScope(session), conf.name))) match {
       case Some(ScalarValue(_, _, SString(stored))) =>
-        VectorValue(schema.name, OneHotEncoder.fromValues(List(stored), schema.field.possibleValues, dim), dim)
+        VectorValue(schema.name, OneHotEncoder.fromValues(List(stored), schema.field.possibleValues, dim.dim), dim)
       case _ =>
-        VectorValue(schema.name, OneHotEncoder.fromValues(parse(request), schema.field.possibleValues, dim), dim)
+        VectorValue(schema.name, OneHotEncoder.fromValues(parse(request), schema.field.possibleValues, dim.dim), dim)
     }
   }
 
@@ -82,7 +83,7 @@ object UserAgentFeature {
   }
 
   trait UAField {
-    lazy val dim: Int = possibleValues.size
+    lazy val dim = VectorDim(possibleValues.size)
     def possibleValues: List[String]
     def value(client: Client): Option[String]
   }

--- a/src/main/scala/ai/metarank/feature/WindowInteractionCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/WindowInteractionCountFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.WindowInteractionCountFeature.WindowInteractionCountSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.VectorDim
 import ai.metarank.model.Event.{InteractionEvent, ItemRelevancy}
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.PeriodicCounterFeature.{PeriodRange, PeriodicCounterConfig}
@@ -19,7 +20,7 @@ import shapeless.syntax.typeable.typeableOps
 import scala.concurrent.duration._
 
 case class WindowInteractionCountFeature(schema: WindowInteractionCountSchema) extends ItemFeature {
-  override val dim: Int = schema.periods.size
+  override val dim = VectorDim(schema.periods.size)
 
   val conf = PeriodicCounterConfig(
     scope = schema.scope,
@@ -54,7 +55,7 @@ case class WindowInteractionCountFeature(schema: WindowInteractionCountSchema) e
     val result = for {
       key      <- readKey(request, conf, id.id)
       value    <- features.get(key)
-      valueNum <- value.cast[PeriodicCounterValue] if valueNum.values.size == dim
+      valueNum <- value.cast[PeriodicCounterValue] if valueNum.values.size == dim.dim
     } yield {
       VectorValue(schema.name, valueNum.values.map(_.value.toDouble).toArray, dim)
     }

--- a/src/main/scala/ai/metarank/feature/WordCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/WordCountFeature.scala
@@ -3,6 +3,7 @@ package ai.metarank.feature
 import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.WordCountFeature.WordCountSchema
 import ai.metarank.fstore.Persistence
+import ai.metarank.model.Dimension.SingleDim
 import ai.metarank.model.Event.ItemRelevancy
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig
@@ -21,7 +22,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import scala.concurrent.duration._
 
 case class WordCountFeature(schema: WordCountSchema) extends ItemFeature with Logging {
-  override def dim: Int = 1
+  override def dim = SingleDim
 
   private val conf = ScalarConfig(
     scope = schema.scope,

--- a/src/main/scala/ai/metarank/feature/ua/PlatformField.scala
+++ b/src/main/scala/ai/metarank/feature/ua/PlatformField.scala
@@ -1,6 +1,7 @@
 package ai.metarank.feature.ua
 
 import ai.metarank.feature.UserAgentFeature.UAField
+import ai.metarank.model.Dimension.VectorDim
 import ua_parser.Client
 
 case object PlatformField extends UAField {
@@ -38,7 +39,7 @@ case object PlatformField extends UAField {
   )
 
   override lazy val possibleValues = List("mobile", "desktop", "tablet")
-  override lazy val dim            = possibleValues.size
+  override lazy val dim            = VectorDim(possibleValues.size)
 
   override def value(client: Client): Option[String] = {
     if (client.os.family == "iOS") {

--- a/src/main/scala/ai/metarank/flow/ClickthroughQuery.scala
+++ b/src/main/scala/ai/metarank/flow/ClickthroughQuery.scala
@@ -54,7 +54,7 @@ object ClickthroughQuery {
             case None    => throw new IllegalStateException("offset missing")
           }
         case MValue.VectorValue(name, values, dim) =>
-          dataset.offsets.get(VectorFeature(name.value, dim)) match {
+          dataset.offsets.get(VectorFeature(name.value, dim.dim)) match {
             case Some(o) => System.arraycopy(values, 0, buffer, o, values.length)
             case None    => throw new IllegalStateException("offset missing")
           }

--- a/src/main/scala/ai/metarank/model/Dimension.scala
+++ b/src/main/scala/ai/metarank/model/Dimension.scala
@@ -1,0 +1,12 @@
+package ai.metarank.model
+
+sealed trait Dimension {
+  def dim: Int
+}
+
+object Dimension {
+  case class VectorDim(dim: Int) extends Dimension
+  case object SingleDim extends Dimension {
+    override val dim = 1
+  }
+}

--- a/src/test/scala/ai/metarank/util/FeatureMappingTest.scala
+++ b/src/test/scala/ai/metarank/util/FeatureMappingTest.scala
@@ -1,0 +1,41 @@
+package ai.metarank.util
+
+import ai.metarank.FeatureMapping
+import ai.metarank.config.ModelConfig.LambdaMARTConfig
+import ai.metarank.config.ModelConfig.ModelBackend.XGBoostBackend
+import ai.metarank.feature.InteractionCountFeature.InteractionCountSchema
+import ai.metarank.feature.WindowInteractionCountFeature.WindowInteractionCountSchema
+import ai.metarank.model.Key.FeatureName
+import ai.metarank.model.ScopeType.ItemScopeType
+import ai.metarank.rank.LambdaMARTModel
+import cats.data.NonEmptyList
+import io.github.metarank.ltrlib.model.Feature.VectorFeature
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class FeatureMappingTest extends AnyFlatSpec with Matchers {
+  it should "use vector features for single-bucket counters" in {
+    val mapping = FeatureMapping.fromFeatureSchema(
+      schema = NonEmptyList.one(
+        WindowInteractionCountSchema(
+          name = FeatureName("clicks"),
+          interaction = "click",
+          scope = ItemScopeType,
+          bucket = 24.hours,
+          periods = List(7)
+        )
+      ),
+      models = Map(
+        "xgboost" -> LambdaMARTConfig(
+          backend = XGBoostBackend(),
+          features = NonEmptyList.one(FeatureName("clicks")),
+          weights = Map("click" -> 1)
+        )
+      )
+    )
+    val datasetFeatures = mapping.models.values.flatMap(_.datasetDescriptor.features).toList
+    datasetFeatures shouldBe List(VectorFeature("clicks", 1))
+  }
+}


### PR DESCRIPTION
So when we define something like this in config:
```yaml

  - name: day_item_click_count
    type: window_count
    interaction: click
    scope: item
    bucket: 24h
    periods: [60]
```

The dataset descriptor cannot distinguish between singular values (as their dimension is 1) and a vector value (with also a dimension of 1). The encoding may be different, so it should be separate. But it wasn't.