### PR TITLE
Fix improper cache TTL expiration on data import

### DIFF
--- a/doc/configuration/overview.md
+++ b/doc/configuration/overview.md
@@ -33,7 +33,7 @@ state: # a place to store the feature values for the ML inference and the traine
     # Metarank implements several optimization strategies when using Redis: caching and pipelining
     # Check https://docs.metarank.ai/reference/overview/persistence#redis-persistence for more details
     #cache:           # optional
-    #  maxSize: 1024  # size of in-memory client-side cache for hot keys, optional, default=1024
+    #  maxSize: 4096  # size of in-memory client-side cache for hot keys, optional, default=4096
     #  ttl: 1h        # how long should key-values should be cached, optional, default=1h
 
     #pipeline:         # optional

--- a/doc/configuration/sample-config.yml
+++ b/doc/configuration/sample-config.yml
@@ -78,7 +78,7 @@ state: # a place to store the feature values for the ML inference and the traine
     # Metarank implements several optimization strategies when using Redis: caching and pipelining
     # Check https://docs.metarank.ai/reference/overview/persistence#redis-persistence for more details
     #cache:           # optional
-    #  maxSize: 1024  # size of in-memory client-side cache for hot keys, optional, default=1024
+    #  maxSize: 4096  # size of in-memory client-side cache for hot keys, optional, default=4096
     #  ttl: 1h        # how long should key-values should be cached, optional, default=1h
 
     #pipeline:         # optional

--- a/src/main/scala/ai/metarank/config/StateStoreConfig.scala
+++ b/src/main/scala/ai/metarank/config/StateStoreConfig.scala
@@ -37,7 +37,8 @@ object StateStoreConfig extends Logging {
       }
     )
 
-    case class CacheConfig(maxSize: Int = 1024, ttl: FiniteDuration = 1.hour)
+    case class CacheConfig(maxSize: Int = 4096, ttl: FiniteDuration = 1.hour)
+
     implicit val cacheConfigDecoder: Decoder[CacheConfig] = Decoder.instance(c =>
       for {
         maxSize <- c.downField("maxSize").as[Option[Int]]

--- a/src/main/scala/ai/metarank/flow/MetarankFlow.scala
+++ b/src/main/scala/ai/metarank/flow/MetarankFlow.scala
@@ -23,6 +23,7 @@ object MetarankFlow {
       eventCounter  <- Ref.of[IO, Long](0)
       updateCounter <- Ref.of[IO, Long](0)
       _ <- source
+        .evalTapChunk(e => IO(store.ticker.tick(e)))
         .evalTapChunk(_ => eventCounter.update(_ + 1))
         .through(ai.metarank.flow.PrintProgress.tap)
         .flatMap(event =>

--- a/src/main/scala/ai/metarank/fstore/EventTicker.scala
+++ b/src/main/scala/ai/metarank/fstore/EventTicker.scala
@@ -1,0 +1,12 @@
+package ai.metarank.fstore
+
+import ai.metarank.model.Event
+import com.github.benmanes.caffeine.cache.Ticker
+
+class EventTicker extends Ticker {
+  var last = 0L
+  def tick(event: Event) = {
+    last = event.timestamp.ts * 1000000
+  }
+  override def read(): Long = last
+}

--- a/src/main/scala/ai/metarank/fstore/Persistence.scala
+++ b/src/main/scala/ai/metarank/fstore/Persistence.scala
@@ -15,28 +15,15 @@ import ai.metarank.model.Feature.{
   ScalarFeature,
   StatsEstimatorFeature
 }
-import ai.metarank.model.Identifier.ItemId
 import ai.metarank.model.Key.FeatureName
-import ai.metarank.model.{
-  Clickthrough,
-  ClickthroughValues,
-  EventId,
-  Feature,
-  FeatureKey,
-  FeatureValue,
-  ItemValue,
-  Key,
-  MValue,
-  Schema,
-  Scope,
-  Write
-}
+import ai.metarank.model.{ClickthroughValues, FeatureKey, FeatureValue, Key, Schema, Scope}
 import ai.metarank.rank.Model.Scorer
 import ai.metarank.util.Logging
 import cats.effect.{IO, Resource}
 import io.circe.Codec
 
 trait Persistence {
+  lazy val ticker = new EventTicker
 
   def schema: Schema
   def counters: Map[FeatureKey, CounterFeature]

--- a/src/main/scala/ai/metarank/fstore/memory/MemClickthroughStore.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemClickthroughStore.scala
@@ -1,14 +1,13 @@
 package ai.metarank.fstore.memory
 
 import ai.metarank.fstore.Persistence.ClickthroughStore
-import ai.metarank.model.{Clickthrough, ClickthroughValues, Event, EventId, Identifier, ItemValue}
+import ai.metarank.model.ClickthroughValues
 import cats.effect.IO
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
-
-import scala.collection.mutable
+import shapeless.syntax.typeable._
 
 case class MemClickthroughStore(
-    cache: Cache[String, ClickthroughValues] = Scaffeine().build[String, ClickthroughValues]()
+    cache: Cache[String, AnyRef] = Scaffeine().build[String, AnyRef]()
 ) extends ClickthroughStore {
 
   override def put(cts: List[ClickthroughValues]): IO[Unit] = IO {
@@ -16,5 +15,5 @@ case class MemClickthroughStore(
   }
 
   override def getall(): fs2.Stream[IO, ClickthroughValues] =
-    fs2.Stream.emits(cache.asMap().values.toList)
+    fs2.Stream.emits(cache.asMap().values.toList.flatMap(_.cast[ClickthroughValues]))
 }

--- a/src/main/scala/ai/metarank/fstore/memory/MemCounter.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemCounter.scala
@@ -7,16 +7,17 @@ import ai.metarank.model.{Key, Timestamp}
 import ai.metarank.model.Write.Increment
 import cats.effect.IO
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import shapeless.syntax.typeable._
 
-case class MemCounter(config: CounterConfig, cache: Cache[Key, Long] = Scaffeine().build()) extends CounterFeature {
+case class MemCounter(config: CounterConfig, cache: Cache[Key, AnyRef] = Scaffeine().build()) extends CounterFeature {
   override def put(action: Increment): IO[Unit] = IO {
-    cache.getIfPresent(action.key) match {
-      case Some(counter) => cache.put(action.key, counter + action.inc)
-      case None          => cache.put(action.key, action.inc)
+    cache.getIfPresent(action.key).flatMap(_.cast[Long]) match {
+      case Some(counter) => cache.put(action.key, Long.box(counter + action.inc))
+      case None          => cache.put(action.key, Long.box(action.inc))
     }
 
   }
   override def computeValue(key: Key, ts: Timestamp): IO[Option[CounterValue]] = IO {
-    cache.getIfPresent(key).map(c => CounterValue(key, ts, c))
+    cache.getIfPresent(key).flatMap(_.cast[Long]).map(c => CounterValue(key, ts, c))
   }
 }

--- a/src/main/scala/ai/metarank/fstore/memory/MemKVStore.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemKVStore.scala
@@ -4,7 +4,7 @@ import ai.metarank.fstore.Persistence.KVStore
 import cats.effect.IO
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 
-case class MemKVStore[K, V](cache: Cache[K, V] = Scaffeine().build[K, V]()) extends KVStore[K, V] {
+case class MemKVStore[K, V <: AnyRef](cache: Cache[K, V] = Scaffeine().build[K, V]()) extends KVStore[K, V] {
   override def get(keys: List[K]): IO[Map[K, V]] =
     IO(keys.flatMap(key => cache.getIfPresent(key).map(v => key -> v)).toMap)
 

--- a/src/main/scala/ai/metarank/fstore/memory/MemModelStore.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemModelStore.scala
@@ -1,0 +1,17 @@
+package ai.metarank.fstore.memory
+
+import ai.metarank.fstore.Persistence.{KVStore, ModelName}
+import ai.metarank.rank.Model.Scorer
+import cats.effect.IO
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import shapeless.syntax.typeable._
+
+case class MemModelStore(cache: Cache[ModelName, AnyRef] = Scaffeine().build()) extends KVStore[ModelName, Scorer] {
+  override def get(keys: List[ModelName]): IO[Map[ModelName, Scorer]] =
+    IO(keys.flatMap(key => cache.getIfPresent(key).flatMap(_.cast[Scorer]).map(v => key -> v)).toMap)
+
+  override def put(values: Map[ModelName, Scorer]): IO[Unit] = IO {
+    values.foreach { case (k, v) => cache.put(k, v) }
+  }
+
+}

--- a/src/main/scala/ai/metarank/fstore/memory/MemPeriodicCounter.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemPeriodicCounter.scala
@@ -7,26 +7,32 @@ import ai.metarank.model.Write.PeriodicIncrement
 import ai.metarank.model.{Key, Timestamp}
 import cats.effect.IO
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import shapeless.syntax.typeable._
 
 case class MemPeriodicCounter(
     config: PeriodicCounterConfig,
-    cache: Cache[Key, Map[Timestamp, Long]] = Scaffeine().build()
+    cache: Cache[Key, AnyRef] = Scaffeine().build()
 ) extends PeriodicCounterFeature {
   override def put(action: PeriodicIncrement): IO[Unit] = IO {
-    cache.getIfPresent(action.key) match {
+    cache.getIfPresent(action.key).flatMap(_.cast[Map[Timestamp, Long]]) match {
       case None =>
-        cache.put(action.key, Map(action.ts.toStartOfPeriod(config.period) -> action.inc))
+        cache.put(action.key, Map(action.ts.toStartOfPeriod(config.period) -> Long.box(action.inc)))
       case Some(counters) =>
         val timeKey = action.ts.toStartOfPeriod(config.period)
         val incremented = counters.get(timeKey) match {
           case Some(count) => count + action.inc
           case None        => action.inc.toLong
         }
-        cache.put(action.key, counters + (timeKey -> incremented))
+        cache.put(action.key, counters + (timeKey -> Long.box(incremented)))
     }
   }
 
   override def computeValue(key: Key, ts: Timestamp): IO[Option[PeriodicCounterValue]] =
-    IO(cache.getIfPresent(key).map(values => PeriodicCounterValue(key, ts, fromMap(values))))
+    IO(
+      cache
+        .getIfPresent(key)
+        .flatMap(_.cast[Map[Timestamp, Long]])
+        .map(values => PeriodicCounterValue(key, ts, fromMap(values)))
+    )
 
 }

--- a/src/main/scala/ai/metarank/fstore/memory/MemPersistence.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemPersistence.scala
@@ -1,25 +1,53 @@
 package ai.metarank.fstore.memory
 
+import ai.metarank.config.StateStoreConfig.RedisStateConfig.CacheConfig
 import ai.metarank.fstore.Persistence
-import ai.metarank.fstore.Persistence.KVCodec
-import ai.metarank.model.{FeatureValue, Key, Schema}
+import ai.metarank.fstore.Persistence.{KVCodec, ModelName}
+import ai.metarank.fstore.memory.MemPersistence.FeatureStateExpiry
+import ai.metarank.model.{FeatureKey, FeatureValue, Key, Schema}
 import ai.metarank.rank.Model.Scorer
+import ai.metarank.util.Logging
 import cats.effect.IO
+import com.github.benmanes.caffeine.cache.{Caffeine, Expiry}
+import com.github.blemale.scaffeine.Scaffeine
 
 case class MemPersistence(schema: Schema) extends Persistence {
-  override lazy val counters         = schema.counters.view.mapValues(MemCounter(_)).toMap
-  override lazy val periodicCounters = schema.periodicCounters.view.mapValues(MemPeriodicCounter(_)).toMap
-  override lazy val lists            = schema.lists.view.mapValues(MemBoundedList(_)).toMap
-  override lazy val freqs            = schema.freqs.view.mapValues(MemFreqEstimator(_)).toMap
-  override lazy val scalars          = schema.scalars.view.mapValues(MemScalarFeature(_)).toMap
-  override lazy val stats            = schema.stats.view.mapValues(MemStatsEstimator(_)).toMap
-  override lazy val maps             = schema.maps.view.mapValues(MemMapFeature(_)).toMap
+  val cache =
+    Scaffeine(Caffeine.newBuilder().ticker(ticker).expireAfter(FeatureStateExpiry(schema))).build[Key, AnyRef]()
 
-  override lazy val models: Persistence.KVStore[Persistence.ModelName, Scorer] = MemKVStore()
-  override lazy val values: Persistence.KVStore[Key, FeatureValue]             = MemKVStore()
+  override lazy val counters         = schema.counters.view.mapValues(MemCounter(_, cache)).toMap
+  override lazy val periodicCounters = schema.periodicCounters.view.mapValues(MemPeriodicCounter(_, cache)).toMap
+  override lazy val lists            = schema.lists.view.mapValues(MemBoundedList(_, cache)).toMap
+  override lazy val freqs            = schema.freqs.view.mapValues(MemFreqEstimator(_, cache)).toMap
+  override lazy val scalars          = schema.scalars.view.mapValues(MemScalarFeature(_, cache)).toMap
+  override lazy val stats            = schema.stats.view.mapValues(MemStatsEstimator(_, cache)).toMap
+  override lazy val maps             = schema.maps.view.mapValues(MemMapFeature(_, cache)).toMap
+
+  override lazy val models: Persistence.KVStore[ModelName, Scorer] = MemModelStore()
+  override lazy val values: Persistence.KVStore[Key, FeatureValue] = MemKVStore()
 
   override lazy val cts: Persistence.ClickthroughStore = MemClickthroughStore()
   override def healthcheck(): IO[Unit]                 = IO.unit
   override def sync: IO[Unit]                          = IO.unit
 
+}
+
+object MemPersistence {
+  case class FeatureStateExpiry(schema: Schema) extends Expiry[Key, AnyRef] with Logging {
+    override def expireAfterCreate(key: Key, value: scala.AnyRef, currentTime: Long): Long =
+      expiration(key, currentTime, Long.MaxValue)
+    override def expireAfterUpdate(key: Key, value: scala.AnyRef, currentTime: Long, currentDuration: Long): Long =
+      expiration(key, currentTime, currentDuration)
+
+    override def expireAfterRead(key: Key, value: scala.AnyRef, currentTime: Long, currentDuration: Long): Long =
+      currentDuration
+
+    def expiration(key: Key, currentTime: Long, currentDuration: Long): Long =
+      schema.configs.get(FeatureKey(key)) match {
+        case Some(conf) => currentTime + conf.ttl.toNanos
+        case None =>
+          logger.warn(s"cannot compute expiration for key $key")
+          currentDuration
+      }
+  }
 }

--- a/src/main/scala/ai/metarank/fstore/memory/MemScalarFeature.scala
+++ b/src/main/scala/ai/metarank/fstore/memory/MemScalarFeature.scala
@@ -7,12 +7,13 @@ import ai.metarank.model.Write.Put
 import ai.metarank.model.{Key, Scalar, Timestamp}
 import cats.effect.IO
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import shapeless.syntax.typeable._
 
-case class MemScalarFeature(config: ScalarConfig, cache: Cache[Key, Scalar] = Scaffeine().build())
+case class MemScalarFeature(config: ScalarConfig, cache: Cache[Key, AnyRef] = Scaffeine().build())
     extends ScalarFeature {
   override def put(action: Put): IO[Unit] = IO(cache.put(action.key, action.value))
 
   override def computeValue(key: Key, ts: Timestamp): IO[Option[ScalarValue]] =
-    IO(cache.getIfPresent(key).map(ScalarValue(key, ts, _)))
+    IO(cache.getIfPresent(key).flatMap(_.cast[Scalar]).map(ScalarValue(key, ts, _)))
 
 }

--- a/src/main/scala/ai/metarank/main/CliArgs.scala
+++ b/src/main/scala/ai/metarank/main/CliArgs.scala
@@ -189,12 +189,19 @@ object CliArgs extends Logging {
       SourceOffset.RelativeDuration(FiniteDuration(num.toLong, suffix))
     case other => throw new IllegalArgumentException(s"cannot parse offset $other")
   })
+
   implicit val formatConverter: ValueConverter[SourceFormat] = singleArgConverter(conv = {
     case "json"          => JsonFormat
     case "snowplow"      => SnowplowTSVFormat
     case "snowplow:tsv"  => SnowplowTSVFormat
     case "snowplow:json" => SnowplowJSONFormat
     case other           => throw new IllegalArgumentException(s"format $other is not supported")
+  })
+
+  implicit val booleanConverter: ValueConverter[Boolean] = singleArgConverter({
+    case "yes" | "true" | "on"  => true
+    case "no" | "false" | "off" => false
+    case other                  => throw new IllegalArgumentException(s"cannot parse $other as boolean valus")
   })
 
 }

--- a/src/main/scala/ai/metarank/main/command/Standalone.scala
+++ b/src/main/scala/ai/metarank/main/command/Standalone.scala
@@ -39,6 +39,7 @@ object Standalone extends Logging {
           case (other, _) =>
             info(s"skipping model $other")
         }.sequence
+        _ <- IO(System.gc())
         _ <- Serve.api(store, mapping, conf.api, buffer)
       } yield {}
     )

--- a/src/test/scala/ai/metarank/fstore/memory/MemCounterTest.scala
+++ b/src/test/scala/ai/metarank/fstore/memory/MemCounterTest.scala
@@ -7,5 +7,5 @@ import ai.metarank.model.Write.Increment
 import com.github.blemale.scaffeine.Scaffeine
 
 class MemCounterTest extends CounterSuite with MemTest[Increment, CounterFeature] {
-  override val feature = MemCounter(config, Scaffeine().build[Key, Long]())
+  override val feature = MemCounter(config)
 }

--- a/src/test/scala/ai/metarank/main/CliArgsTest.scala
+++ b/src/test/scala/ai/metarank/main/CliArgsTest.scala
@@ -34,6 +34,15 @@ class CliArgsTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "parse import with no validation" in {
+    CliArgs.parse(
+      List("import", "-c", conf.toString, "-d", data.toString, "--validation=false"),
+      Map.empty
+    ) shouldBe Right(
+      ImportArgs(conf, data, SourceOffset.Earliest, JsonFormat, false)
+    )
+  }
+
   it should "parse train args, short" in {
     CliArgs.parse(List("train", "-c", conf.toString, "-m", "xgboost"), Map.empty) shouldBe Right(
       TrainArgs(conf, "xgboost")

--- a/src/test/scala/ai/metarank/util/SyntheticRanklensDataset.scala
+++ b/src/test/scala/ai/metarank/util/SyntheticRanklensDataset.scala
@@ -1,0 +1,88 @@
+package ai.metarank.util
+
+import ai.metarank.model.Event.{InteractionEvent, ItemEvent, ItemRelevancy, RankingEvent}
+import ai.metarank.model.Field.{NumberField, StringField, StringListField}
+import ai.metarank.model.Identifier.{ItemId, SessionId, UserId}
+import ai.metarank.model.{Event, EventId, Timestamp}
+import cats.data.NonEmptyList
+
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.util.Random
+
+object SyntheticRanklensDataset {
+  def main(args: Array[String]): Unit = {
+    val events = apply(users = 10000)
+    val br     = 1
+  }
+  def apply(
+      start: Timestamp = Timestamp.date(2022, 9, 1, 0, 0, 0),
+      period: FiniteDuration = 30.days,
+      items: Int = 1000,
+      users: Int = 1000,
+      rankingsPerUser: Int = 10,
+      clicksPerRanking: Int = 2
+  ) = {
+    val events   = RanklensEvents().collect { case i: ItemEvent => i }
+    val genres   = events.flatMap(_.fields.collect { case g @ StringListField("genres", _) => g }).toArray
+    val director = events.flatMap(_.fields.collect { case g @ StringField("director", _) => g }).toArray
+    val tags     = events.flatMap(_.fields.collect { case g @ StringListField("tags", _) => g }).toArray
+    val actors   = events.flatMap(_.fields.collect { case g @ StringListField("actors", _) => g }).toArray
+
+    val itemEvents = for {
+      i <- (0 until items).toArray
+    } yield {
+      ItemEvent(
+        id = EventId(UUID.randomUUID().toString),
+        item = ItemId(i.toString),
+        timestamp = start,
+        fields = List(
+          genres(Random.nextInt(genres.length)),
+          tags(Random.nextInt(tags.length)),
+          actors(Random.nextInt(actors.length)),
+          director(Random.nextInt(director.length)),
+          StringField("title", s"Film ${i}"),
+          NumberField("popularity", Random.nextInt(100000)),
+          NumberField("vote_avg", Random.nextInt(10)),
+          NumberField("vote_cnt", Random.nextInt(1000)),
+          NumberField("budget", Random.nextInt(100000000)),
+          NumberField("runtime", 50 + Random.nextInt(120))
+        )
+      )
+    }
+
+    val userIds = (0 until users).map(i => UserId(i.toString)).toArray
+
+    val rankings = for {
+      user <- userIds
+      i    <- 0 until rankingsPerUser
+    } yield {
+      RankingEvent(
+        id = EventId(UUID.randomUUID().toString),
+        timestamp = start.plus(Random.nextLong(period.toMillis).millis),
+        user = user,
+        session = Some(SessionId(user.value)),
+        items = NonEmptyList.fromListUnsafe(
+          (0 until 10).map(_ => ItemRelevancy(itemEvents(Random.nextInt(itemEvents.length)).item, 1.0)).toList
+        )
+      )
+    }
+
+    val clicks = for {
+      ranking       <- rankings
+      (item, index) <- Random.shuffle(ranking.items.map(_.id).toList).take(clicksPerRanking).zipWithIndex
+    } yield {
+      InteractionEvent(
+        id = EventId(UUID.randomUUID().toString),
+        item = item,
+        timestamp = ranking.timestamp.plus((10 + index * Random.nextInt(10)).seconds),
+        user = ranking.user,
+        session = ranking.session,
+        ranking = Some(ranking.id),
+        `type` = "click"
+      )
+    }
+
+    (itemEvents.toList ++ rankings.toList ++ clicks.toList).sortBy(_.timestamp.ts)
+  }
+}


### PR DESCRIPTION
No the caching is much more granular:
* mem store properly obeys the feature TTL
* there is now a single state cache for redis store (and not per feature type, which is hard to control)
* fix issue with `--validation=false` flag not being parsed properly
* ranklens dataset generator to do permutations for synthetic data