### PR TITLE
make 'train --model' option optional

### DIFF
--- a/src/test/scala/ai/metarank/main/CliArgsTest.scala
+++ b/src/test/scala/ai/metarank/main/CliArgsTest.scala
@@ -46,7 +46,13 @@ class CliArgsTest extends AnyFlatSpec with Matchers {
 
   it should "parse train args, short" in {
     CliArgs.parse(List("train", "-c", conf.toString, "-m", "xgboost"), Map.empty) shouldBe Right(
-      TrainArgs(conf, "xgboost")
+      TrainArgs(conf, Some("xgboost"))
+    )
+  }
+
+  it should "parse train args, no model" in {
+    CliArgs.parse(List("train", "-c", conf.toString), Map.empty) shouldBe Right(
+      TrainArgs(conf, None)
     )
   }
 

--- a/src/test/scala/ai/metarank/model/AnalyticsPayloadTest.scala
+++ b/src/test/scala/ai/metarank/model/AnalyticsPayloadTest.scala
@@ -10,7 +10,7 @@ import java.nio.file.Path
 
 class AnalyticsPayloadTest extends AnyFlatSpec with Matchers {
   it should "generate payload" in {
-    val payload = AnalyticsPayload(TestConfig(), TrainArgs(Path.of("x"), "foo"))
+    val payload = AnalyticsPayload(TestConfig(), TrainArgs(Path.of("x"), Some("foo")))
     payload.state shouldBe "memory"
     payload.modelTypes shouldBe List("shuffle")
     payload.usedFeatures shouldBe List(UsedFeature(FeatureName("price"), "number"))


### PR DESCRIPTION
usability improvement: no need to set the option when it's only single model. no option = train all you have