### PR TITLE
fix config decoding error for field_match over terms

### DIFF
--- a/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
+++ b/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
@@ -108,7 +108,7 @@ object FieldMatchFeature {
       tpe <- c.downField("type").as[String]
       method <- tpe match {
         case "ngram" => NgramMatcher.ngramDecoder.apply(c)
-        case "term"  => NgramMatcher.ngramDecoder.apply(c)
+        case "term"  => TermMatcher.termDecoder.apply(c)
         case other   => Left(DecodingFailure(s"match method $other is not supported", c.history))
       }
     } yield {
@@ -123,7 +123,7 @@ object FieldMatchFeature {
         .deepMerge(Json.fromJsonObject(JsonObject.fromMap(Map("type" -> Json.fromString("term")))))
     case t: TermMatcher =>
       TermMatcher
-        .ngramEncoder(t)
+        .termEncoder(t)
         .deepMerge(Json.fromJsonObject(JsonObject.fromMap(Map("type" -> Json.fromString("term")))))
     case _ => ???
   }

--- a/src/main/scala/ai/metarank/feature/matcher/TermMatcher.scala
+++ b/src/main/scala/ai/metarank/feature/matcher/TermMatcher.scala
@@ -12,6 +12,6 @@ case class TermMatcher(language: TextAnalyzer) extends FieldMatcher {
 }
 
 object TermMatcher {
-  implicit val ngramDecoder: Decoder[TermMatcher] = deriveDecoder
-  implicit val ngramEncoder: Encoder[TermMatcher] = deriveEncoder
+  implicit val termDecoder: Decoder[TermMatcher] = deriveDecoder
+  implicit val termEncoder: Encoder[TermMatcher] = deriveEncoder
 }


### PR DESCRIPTION
To reproduce, try to decode the following config snippet:

```yaml
- name: title_match
  type: field_match
  itemField: item.title // must be a string
  rankingField: ranking.query // must be a string
  method:
    type: term // for now only ngram and term are supported
    language: en // ISO-639-1 language code
```