### PR TITLE
fix version detect within docker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,9 +66,13 @@ lazy val root = (project in file("."))
       val artifactTargetPath = s"/app/${artifact.name}"
 
       new Dockerfile {
-        from(s"--platform=$PLATFORM ubuntu:jammy-20221003")
+        from(s"--platform=$PLATFORM ubuntu:jammy-20221020")
         runRaw(
-          "apt-get update && apt-get -y install openjdk-17-jdk-headless openjdk-17-dbg htop procps curl inetutils-ping libgomp1"
+          List(
+            "apt-get update",
+            "apt-get install -y --no-install-recommends openjdk-17-jdk-headless htop procps curl inetutils-ping libgomp1",
+            "rm -rf /var/lib/apt/lists/*"
+          ).mkString(" && ")
         )
         add(new File("deploy/metarank.sh"), "/metarank.sh")
         add(artifact, artifactTargetPath)
@@ -86,6 +90,7 @@ lazy val root = (project in file("."))
     ThisBuild / assemblyMergeStrategy := {
       case PathList("module-info.class")           => MergeStrategy.discard
       case "META-INF/io.netty.versions.properties" => MergeStrategy.first
+      case "META-INF/MANIFEST.MF"                  => MergeStrategy.discard
       case "findbugsExclude.xml"                   => MergeStrategy.discard
       case "log4j2-test.properties"                => MergeStrategy.discard
       case x if x.endsWith("/module-info.class")   => MergeStrategy.discard

--- a/src/main/scala/ai/metarank/util/Version.scala
+++ b/src/main/scala/ai/metarank/util/Version.scala
@@ -3,6 +3,7 @@ package ai.metarank.util
 import org.apache.commons.io.IOUtils
 
 import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 import java.util.jar.Attributes.Name
 import scala.util.Try
 import scala.jdk.CollectionConverters._

--- a/src/test/resources/testmanifest.mf
+++ b/src/test/resources/testmanifest.mf
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Main-Class: ai.metarank.main.Main
 Specification-Title: metarank
-Specification-Version: 0.5.3
+Specification-Version: 0.5.7
 Specification-Vendor: ai.metarank
 Implementation-Title: metarank
-Implementation-Version: 0.5.3
+Implementation-Version: 0.5.7
 Implementation-Vendor: ai.metarank
 Implementation-Vendor-Id: ai.metarank
 

--- a/src/test/scala/ai/metarank/util/VersionTest.scala
+++ b/src/test/scala/ai/metarank/util/VersionTest.scala
@@ -6,6 +6,6 @@ import org.scalatest.matchers.should.Matchers
 class VersionTest extends AnyFlatSpec with Matchers {
   it should "parse release manifest" in {
     val result = Version("/testmanifest.mf")
-    result shouldBe Some("0.5.3")
+    result shouldBe Some("0.5.7")
   }
 }


### PR DESCRIPTION
It was relying on the in-jar MANIFEST.MF file, but openjdk on ubuntu replaced this file with java-atk-wrapper one.