### PR TITLE
Multi-field support for interacted_with extractor

### DIFF
--- a/doc/configuration/features/user-session.md
+++ b/doc/configuration/features/user-session.md
@@ -52,22 +52,32 @@ The UA field is taken from each ranking request, so it should be always present.
 
 ## Interacted with
 
-For the current item, did this visitor have an interaction with other item with the same field.
+For the current item, did this visitor have an interaction with other item with the same field?
 
 Example:
 ```yaml
-- name: clicked_color
+- name: clicked
   type: interacted_with
   # type of the interaction event (interaction.type field)
   interaction: click
-  field: item.color // must be a string or string[], and only works with item fields
+  field: [ item.color ] # the field must be a string or string[], 
+                        # and only works with item fields.
 
   # session/user
   scope: user
 ```
 
-For this example, Metarank will track all color field values for all items visitor clicked and intersect this set 
-with per-item field values in the ranking.
+For this example, Metarank will track all color field values for all items visitor clicked and intersect this set with per-item field values in the ranking.
+
+`interacted_with` extractor can also track multiple fields at once within a single visitor profile:
+
+```yaml
+- name: clicked
+  type: interacted_with
+  interaction: click
+  field: [ item.color, item.tags, item.brand ] # multiple fields at once
+  scope: user
+```
 
 ## Referer
 

--- a/src/main/scala/ai/metarank/FeatureMapping.scala
+++ b/src/main/scala/ai/metarank/FeatureMapping.scala
@@ -33,9 +33,6 @@ case class FeatureMapping(
     schema: Schema,
     models: Map[String, Model]
 ) extends Logging {
-  def stateReadKeys(request: RankingEvent): List[Key] = {
-    features.flatMap(_.valueKeys(request).toList)
-  }
 
   def optimize(): FeatureMapping = {
     val referencedNames = models.values.flatMap {

--- a/src/main/scala/ai/metarank/feature/BaseFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BaseFeature.scala
@@ -34,6 +34,9 @@ sealed trait BaseFeature {
 
   def valueKeys(event: RankingEvent): Iterable[Key]
 
+  def valueKeysSecondPass(event: RankingEvent, keys: Iterable[Key], features: Map[Key, FeatureValue]): Iterable[Key] =
+    keys
+
 }
 
 object BaseFeature {

--- a/src/main/scala/ai/metarank/feature/BaseFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BaseFeature.scala
@@ -13,7 +13,7 @@ sealed trait BaseFeature {
   def dim: Dimension
   def schema: FeatureSchema
   def states: List[FeatureConfig]
-  def writes(event: Event, features: Persistence): IO[Iterable[Write]]
+  def writes(event: Event): IO[Iterable[Write]]
 
   def writeKey(event: Event, feature: FeatureConfig): Option[Key] = (feature.scope, event) match {
     case (GlobalScopeType, _)                    => Some(Key(GlobalScope, feature.name))
@@ -34,8 +34,7 @@ sealed trait BaseFeature {
 
   def valueKeys(event: RankingEvent): Iterable[Key]
 
-  def valueKeysSecondPass(event: RankingEvent, keys: Iterable[Key], features: Map[Key, FeatureValue]): Iterable[Key] =
-    keys
+  def valueKeys2(event: RankingEvent, features: Map[Key, FeatureValue]): Iterable[Key] = Nil
 
 }
 

--- a/src/main/scala/ai/metarank/feature/BooleanFeature.scala
+++ b/src/main/scala/ai/metarank/feature/BooleanFeature.scala
@@ -33,7 +33,7 @@ case class BooleanFeature(schema: BooleanFeatureSchema) extends ItemFeature with
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, features: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.source.field)

--- a/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
+++ b/src/main/scala/ai/metarank/feature/FieldMatchFeature.scala
@@ -36,7 +36,7 @@ case class FieldMatchFeature(schema: FieldMatchSchema) extends ItemFeature with 
 
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, features: Persistence): IO[Iterable[Write]] = IO {
+  override def writes(event: Event): IO[Iterable[Write]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.itemField.field)

--- a/src/main/scala/ai/metarank/feature/InteractionCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/InteractionCountFeature.scala
@@ -30,7 +30,7 @@ case class InteractionCountFeature(schema: InteractionCountSchema) extends ItemF
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, store: Persistence): IO[Iterable[Increment]] = IO {
+  override def writes(event: Event): IO[Iterable[Increment]] = IO {
     event match {
       case interaction: Event.InteractionEvent if interaction.`type` == schema.interaction =>
         writeKey(event, conf).map(key => Increment(key, event.timestamp, 1))

--- a/src/main/scala/ai/metarank/feature/ItemAgeFeature.scala
+++ b/src/main/scala/ai/metarank/feature/ItemAgeFeature.scala
@@ -37,7 +37,7 @@ case class ItemAgeFeature(schema: ItemAgeSchema) extends ItemFeature with Loggin
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, store: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.source.field)

--- a/src/main/scala/ai/metarank/feature/LocalDateTimeFeature.scala
+++ b/src/main/scala/ai/metarank/feature/LocalDateTimeFeature.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
 case class LocalDateTimeFeature(schema: LocalDateTimeSchema) extends RankingFeature with Logging {
   override def dim                                                          = SingleDim
   override def states: List[FeatureConfig]                                  = Nil
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO.pure(Nil)
+  override def writes(event: Event): IO[Iterable[Put]] = IO.pure(Nil)
 
   override def valueKeys(event: Event.RankingEvent): Iterable[Key] = Nil
   override def value(

--- a/src/main/scala/ai/metarank/feature/NumVectorFeature.scala
+++ b/src/main/scala/ai/metarank/feature/NumVectorFeature.scala
@@ -36,7 +36,7 @@ case class NumVectorFeature(schema: VectorFeatureSchema) extends ItemFeature wit
 
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     val br = 1
     for {
       key   <- writeKey(event, conf)

--- a/src/main/scala/ai/metarank/feature/NumberFeature.scala
+++ b/src/main/scala/ai/metarank/feature/NumberFeature.scala
@@ -33,7 +33,7 @@ case class NumberFeature(schema: NumberFeatureSchema) extends ItemFeature with L
 
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.source.field)

--- a/src/main/scala/ai/metarank/feature/PositionFeature.scala
+++ b/src/main/scala/ai/metarank/feature/PositionFeature.scala
@@ -23,7 +23,7 @@ case class PositionFeature(schema: PositionFeatureSchema) extends ItemFeature wi
 
   override def states: List[FeatureConfig] = Nil
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO.pure(Nil)
+  override def writes(event: Event): IO[Iterable[Put]] = IO.pure(Nil)
 
   override def valueKeys(event: Event.RankingEvent): Iterable[Key] = Nil
 

--- a/src/main/scala/ai/metarank/feature/RateFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RateFeature.scala
@@ -62,7 +62,7 @@ case class RateFeature(schema: RateFeatureSchema) extends ItemFeature {
 
   override def states: List[FeatureConfig] = List(topItem, bottomItem, topGlobal, bottomGlobal)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Write]] = IO {
+  override def writes(event: Event): IO[Iterable[Write]] = IO {
     event match {
       case e: InteractionEvent if e.`type` == schema.top =>
         schema.normalize match {

--- a/src/main/scala/ai/metarank/feature/RefererFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RefererFeature.scala
@@ -66,7 +66,7 @@ case class RefererFeature(schema: RefererSchema) extends RankingFeature with Log
 
   override val states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Write]] = IO {
+  override def writes(event: Event): IO[Iterable[Write]] = IO {
     event match {
       case event: RankingEvent if schema.source.event == Ranking => writeField(event, event.user, event.session)
       case event: InteractionEvent if schema.source.event == Interaction(event.`type`) =>

--- a/src/main/scala/ai/metarank/feature/RelevancyFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RelevancyFeature.scala
@@ -22,7 +22,7 @@ case class RelevancyFeature(schema: RelevancySchema) extends ItemFeature {
 
   override def states: List[FeatureConfig] = Nil
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO.pure(Nil)
+  override def writes(event: Event): IO[Iterable[Put]] = IO.pure(Nil)
 
   override def valueKeys(event: Event.RankingEvent): Iterable[Key] = Nil
 

--- a/src/main/scala/ai/metarank/feature/StringFeature.scala
+++ b/src/main/scala/ai/metarank/feature/StringFeature.scala
@@ -48,7 +48,7 @@ case class StringFeature(schema: StringFeatureSchema) extends ItemFeature with L
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.source.field)

--- a/src/main/scala/ai/metarank/feature/UserAgentFeature.scala
+++ b/src/main/scala/ai/metarank/feature/UserAgentFeature.scala
@@ -37,7 +37,7 @@ case class UserAgentFeature(schema: UserAgentSchema) extends RankingFeature {
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     event match {
       case feedback: Event.FeedbackEvent =>
         for {

--- a/src/main/scala/ai/metarank/feature/WindowInteractionCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/WindowInteractionCountFeature.scala
@@ -33,7 +33,7 @@ case class WindowInteractionCountFeature(schema: WindowInteractionCountSchema) e
 
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Write]] = IO {
+  override def writes(event: Event): IO[Iterable[Write]] = IO {
     for {
       key <- writeKey(event, conf)
       inc <- event match {

--- a/src/main/scala/ai/metarank/feature/WordCountFeature.scala
+++ b/src/main/scala/ai/metarank/feature/WordCountFeature.scala
@@ -32,7 +32,7 @@ case class WordCountFeature(schema: WordCountSchema) extends ItemFeature with Lo
   )
   override def states: List[FeatureConfig] = List(conf)
 
-  override def writes(event: Event, fields: Persistence): IO[Iterable[Put]] = IO {
+  override def writes(event: Event): IO[Iterable[Put]] = IO {
     for {
       key   <- writeKey(event, conf)
       field <- event.fields.find(_.name == schema.source.field)

--- a/src/main/scala/ai/metarank/flow/ClickthroughJoinBuffer.scala
+++ b/src/main/scala/ai/metarank/flow/ClickthroughJoinBuffer.scala
@@ -4,7 +4,7 @@ import ai.metarank.FeatureMapping
 import ai.metarank.config.CoreConfig.ClickthroughJoinConfig
 import ai.metarank.feature.BaseFeature.ValueMode
 import ai.metarank.flow.ClickthroughJoinBuffer.Node
-import ai.metarank.fstore.Persistence
+import ai.metarank.fstore.{FeatureValueLoader, Persistence}
 import ai.metarank.model.Event.{InteractionEvent, RankingEvent}
 import ai.metarank.model.{Clickthrough, ClickthroughValues, Event, ItemValue, Timestamp}
 import ai.metarank.util.Logging
@@ -34,8 +34,7 @@ case class ClickthroughJoinBuffer(
   }
 
   def handleRanking(event: RankingEvent): IO[Unit] = for {
-    keys    <- IO(mapping.features.flatMap(_.valueKeys(event)))
-    values  <- state.values.get(keys)
+    values  <- FeatureValueLoader.fromStateBackend(mapping, event, state)
     mvalues <- IO(ItemValue.fromState(event, values, mapping, ValueMode.OfflineTraining))
     ctv = ClickthroughValues(
       Clickthrough(

--- a/src/main/scala/ai/metarank/flow/FeatureValueFlow.scala
+++ b/src/main/scala/ai/metarank/flow/FeatureValueFlow.scala
@@ -24,7 +24,7 @@ case class FeatureValueFlow(
   def process: Pipe[IO, Event, List[FeatureValue]] = events =>
     events
       .evalMap(event => {
-        mapping.features.map(_.writes(event, store)).sequence.map(_.flatten.toList)
+        mapping.features.map(_.writes(event)).sequence.map(_.flatten.toList)
       })
       .evalMapChunk(writes => {
         writes.map(write => commitWrite(write).map(_ => write)).sequence

--- a/src/main/scala/ai/metarank/fstore/FeatureValueLoader.scala
+++ b/src/main/scala/ai/metarank/fstore/FeatureValueLoader.scala
@@ -1,0 +1,18 @@
+package ai.metarank.fstore
+
+import ai.metarank.FeatureMapping
+import ai.metarank.model.Event.RankingEvent
+import ai.metarank.model.{FeatureValue, Key}
+import cats.effect.IO
+
+object FeatureValueLoader {
+  def fromStateBackend(mapping: FeatureMapping, ranking: RankingEvent, store: Persistence): IO[Map[Key, FeatureValue]] =
+    for {
+      keys1  <- IO { mapping.features.flatMap(_.valueKeys(ranking)) }
+      state1 <- store.values.get(keys1)
+      keys2  <- IO { mapping.features.flatMap(_.valueKeys2(ranking, state1)) }
+      state2 <- store.values.get(keys2)
+    } yield {
+      state1 ++ state2
+    }
+}

--- a/src/main/scala/ai/metarank/fstore/redis/codec/VCodec.scala
+++ b/src/main/scala/ai/metarank/fstore/redis/codec/VCodec.scala
@@ -48,7 +48,7 @@ object VCodec {
   def bincomp[T](codec: BinaryCodec[T]) = new VCodec[T] {
     override def decode(bytes: Array[Byte]): Either[Throwable, T] = {
       val stream = new ByteArrayInputStream(bytes)
-      val in     = new DataInputStream(new BufferedInputStream(new ZstdInputStream(stream), 1024))
+      val in     = new DataInputStream(new BufferedInputStream(new ZstdInputStream(stream), 1024 * 32))
       Try(codec.read(in)) match {
         case Failure(exception) => Left(exception)
         case Success(value)     => Right(value)
@@ -57,7 +57,7 @@ object VCodec {
 
     override def encode(value: T): Array[Byte] = {
       val bytes    = new ByteArrayOutputStream()
-      val buffered = new BufferedOutputStream(new ZstdOutputStream(bytes, 3), 1024)
+      val buffered = new BufferedOutputStream(new ZstdOutputStream(bytes, 3), 1024 * 16)
       val out      = new DataOutputStream(buffered)
       codec.write(value, out)
       buffered.flush()

--- a/src/main/scala/ai/metarank/main/Main.scala
+++ b/src/main/scala/ai/metarank/main/Main.scala
@@ -40,8 +40,12 @@ object Main extends IOApp with Logging {
           )
         _ <- info("Metarank v" + Version().getOrElse("unknown") + " is starting.")
         _ <- args match {
-          case a: AutoFeatureArgs => AutoFeature.run(a)
-          case a: SortArgs        => Sort.run(a)
+          case a: AutoFeatureArgs =>
+            for {
+              _ <- sendUsageAnalytics(TrackingConfig(), AnalyticsPayload(args), env)
+              _ <- AutoFeature.run(a)
+            } yield {}
+          case a: SortArgs => Sort.run(a)
           case confArgs: CliArgs.CliConfArgs =>
             for {
               confString <- IO.fromTry(

--- a/src/main/scala/ai/metarank/main/command/autofeature/rules/InteractedWithFeatureRule.scala
+++ b/src/main/scala/ai/metarank/main/command/autofeature/rules/InteractedWithFeatureRule.scala
@@ -12,23 +12,23 @@ import ai.metarank.util.Logging
 object InteractedWithFeatureRule extends FeatureRule with Logging {
   override def make(model: EventModel): List[FeatureSchema] = for {
     interaction <- model.interactions.types.keys.toList
-    field <- model.itemFields.strings.flatMap {
+  } yield {
+    val fields = model.itemFields.strings.flatMap {
       case (name, stat) if stat.values.size > 1 => Some(name)
       case _                                    => None
     }
-  } yield {
-    make(interaction, field)
+    make(interaction, fields.toList)
   }
 
-  def make(interaction: String, field: String): InteractedWithSchema = {
+  def make(interaction: String, fields: List[String]): InteractedWithSchema = {
     logger.info(
-      s"generated interacted_with feature for interaction '$interaction' over field '${field}'"
+      s"generated interacted_with feature for interaction '$interaction' over fields '${fields.mkString(",")}'"
     )
 
     InteractedWithSchema(
-      name = FeatureName(s"${interaction}_${field}"),
+      name = FeatureName(interaction),
       interaction = interaction,
-      fields = List(FieldName(Item, field)),
+      fields = fields.map(field => FieldName(Item, field)),
       scope = UserScopeType,
       count = None,
       duration = None

--- a/src/main/scala/ai/metarank/main/command/autofeature/rules/InteractedWithFeatureRule.scala
+++ b/src/main/scala/ai/metarank/main/command/autofeature/rules/InteractedWithFeatureRule.scala
@@ -28,7 +28,7 @@ object InteractedWithFeatureRule extends FeatureRule with Logging {
     InteractedWithSchema(
       name = FeatureName(s"${interaction}_${field}"),
       interaction = interaction,
-      field = FieldName(Item, field),
+      fields = List(FieldName(Item, field)),
       scope = UserScopeType,
       count = None,
       duration = None

--- a/src/main/scala/ai/metarank/model/FieldName.scala
+++ b/src/main/scala/ai/metarank/model/FieldName.scala
@@ -6,7 +6,9 @@ import io.circe.{Codec, Decoder, Encoder}
 
 import scala.util.{Failure, Success}
 
-case class FieldName(event: EventType, field: String)
+case class FieldName(event: EventType, field: String) {
+  override def toString: String = s"${event.asString}.$field"
+}
 
 object FieldName {
 

--- a/src/main/scala/ai/metarank/validate/checks/FeatureOverMissingFieldValidation.scala
+++ b/src/main/scala/ai/metarank/validate/checks/FeatureOverMissingFieldValidation.scala
@@ -46,6 +46,7 @@ object FeatureOverMissingFieldValidation extends EventValidation {
       case f @ StringFeatureSchema(_, field, _, _, _, _, _) if !fields.contains(field) => List(f -> field)
       case f @ UserAgentSchema(_, field, _, _, _) if !fields.contains(field)           => List(f -> field)
       case f @ WordCountSchema(_, field, _, _, _) if !fields.contains(field)           => List(f -> field)
+      case _                                                                           => Nil
     }.toMap
     if (brokenRefs.isEmpty) {
       logger.info(s"$name = PASS (${config.features.size} features referencing existing ${fields.size} event fields)")

--- a/src/main/scala/ai/metarank/validate/checks/FeatureOverMissingFieldValidation.scala
+++ b/src/main/scala/ai/metarank/validate/checks/FeatureOverMissingFieldValidation.scala
@@ -34,17 +34,18 @@ object FeatureOverMissingFieldValidation extends EventValidation {
       .flatten
       .toSet
 
-    val brokenRefs: Map[FeatureSchema, FieldName] = config.features.toList.collect {
-      case f @ BooleanFeatureSchema(_, field, _, _, _) if !fields.contains(field)          => f -> field
-      case f @ FieldMatchSchema(_, field, _, _, _, _) if !fields.contains(field)           => f -> field
-      case f @ FieldMatchSchema(_, _, field, _, _, _) if !fields.contains(field)           => f -> field
-      case f @ InteractedWithSchema(_, _, field, _, _, _, _, _) if !fields.contains(field) => f -> field
-      case f @ ItemAgeSchema(_, field, _, _) if !fields.contains(field)                    => f -> field
-      case f @ NumberFeatureSchema(_, field, _, _, _) if !fields.contains(field)           => f -> field
-      case f @ RefererSchema(_, field, _, _, _) if !fields.contains(field)                 => f -> field
-      case f @ StringFeatureSchema(_, field, _, _, _, _, _) if !fields.contains(field)     => f -> field
-      case f @ UserAgentSchema(_, field, _, _, _) if !fields.contains(field)               => f -> field
-      case f @ WordCountSchema(_, field, _, _, _) if !fields.contains(field)               => f -> field
+    val brokenRefs: Map[FeatureSchema, FieldName] = config.features.toList.flatMap {
+      case f @ BooleanFeatureSchema(_, field, _, _, _) if !fields.contains(field) => List(f -> field)
+      case f @ FieldMatchSchema(_, field, _, _, _, _) if !fields.contains(field)  => List(f -> field)
+      case f @ FieldMatchSchema(_, _, field, _, _, _) if !fields.contains(field)  => List(f -> field)
+      case f @ InteractedWithSchema(_, _, fieldSet, _, _, _, _, _) =>
+        fieldSet.filter(f => !fields.contains(f)).map(field => f -> field)
+      case f @ ItemAgeSchema(_, field, _, _) if !fields.contains(field)                => List(f -> field)
+      case f @ NumberFeatureSchema(_, field, _, _, _) if !fields.contains(field)       => List(f -> field)
+      case f @ RefererSchema(_, field, _, _, _) if !fields.contains(field)             => List(f -> field)
+      case f @ StringFeatureSchema(_, field, _, _, _, _, _) if !fields.contains(field) => List(f -> field)
+      case f @ UserAgentSchema(_, field, _, _, _) if !fields.contains(field)           => List(f -> field)
+      case f @ WordCountSchema(_, field, _, _, _) if !fields.contains(field)           => List(f -> field)
     }.toMap
     if (brokenRefs.isEmpty) {
       logger.info(s"$name = PASS (${config.features.size} features referencing existing ${fields.size} event fields)")

--- a/src/test/resources/ranklens/config.yml
+++ b/src/test/resources/ranklens/config.yml
@@ -1,8 +1,8 @@
-state:
-  type: redis
-  host: localhost
-  port: 6379
-  format: binary
+#state:
+#  type: redis
+#  host: localhost
+#  port: 6379
+#  format: binary
 
 core:
   clickthrough:

--- a/src/test/resources/ranklens/config.yml
+++ b/src/test/resources/ranklens/config.yml
@@ -1,8 +1,8 @@
-#state:
-#  type: redis
-#  host: localhost
-#  port: 6379
-#  format: binary
+state:
+  type: redis
+  host: localhost
+  port: 6379
+  format: binary
 
 core:
   clickthrough:
@@ -28,10 +28,7 @@ models:
       - title_length
       - genre
       - ctr
-      - liked_genre
-      - liked_actors
-      - liked_tags
-      - liked_director
+      - profile
       - position
 #      - visitor_click_count
 #      - global_item_click_count
@@ -106,34 +103,10 @@ features:
     normalize:
       weight: 10
 
-  - name: liked_genre
+  - name: profile
     type: interacted_with
     interaction: click
-    field: metadata.genres
-    scope: session
-    count: 100
-    duration: 24h
-
-  - name: liked_actors
-    type: interacted_with
-    interaction: click
-    field: metadata.actors
-    scope: session
-    count: 100
-    duration: 24h
-
-  - name: liked_tags
-    type: interacted_with
-    interaction: click
-    field: metadata.tags
-    scope: session
-    count: 100
-    duration: 24h
-
-  - name: liked_director
-    type: interacted_with
-    interaction: click
-    field: metadata.director
+    field: [item.genres, item.actors, item.tags, item.director]
     scope: session
     count: 100
     duration: 24h

--- a/src/test/scala/ai/metarank/feature/FieldMatchFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/FieldMatchFeatureTest.scala
@@ -44,7 +44,7 @@ class FieldMatchFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
   }
 
   it should "generate puts" in {
-    val puts = feature.writes(event, store).unsafeRunSync().toList
+    val puts = feature.writes(event).unsafeRunSync().toList
     puts shouldBe List(
       Put(
         Key(ItemScope(ItemId("p1")), FeatureName("title_match_title")),

--- a/src/test/scala/ai/metarank/feature/InteractedWithFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/InteractedWithFeatureTest.scala
@@ -30,7 +30,7 @@ class InteractedWithFeatureTest extends AnyFlatSpec with Matchers with FeatureTe
   val conf = InteractedWithSchema(
     name = FeatureName("seen_color"),
     interaction = "impression",
-    field = FieldName(Item, "color"),
+    fields = List(FieldName(Item, "color")),
     scope = SessionScopeType,
     count = Some(10),
     duration = Some(24.hours)
@@ -44,7 +44,7 @@ class InteractedWithFeatureTest extends AnyFlatSpec with Matchers with FeatureTe
   val interactionEvent2 =
     TestInteractionEvent("p2", "i1", Nil).copy(session = Some(SessionId("s1")), `type` = "impression")
 
-  it should "decode config" in {
+  it should "decode config with single field" in {
     val yaml =
       """name: seen_color
         |interaction: impression
@@ -53,6 +53,19 @@ class InteractedWithFeatureTest extends AnyFlatSpec with Matchers with FeatureTe
         |count: 10
         |duration: 24h""".stripMargin
     parse(yaml).flatMap(_.as[InteractedWithSchema]) shouldBe Right(conf)
+  }
+
+  it should "decode config with multiple fields" in {
+    val yaml =
+      """name: seen_color
+        |interaction: impression
+        |field: [item.color, item.brand]
+        |scope: session
+        |count: 10
+        |duration: 24h""".stripMargin
+    parse(yaml).flatMap(_.as[InteractedWithSchema]) shouldBe Right(
+      conf.copy(fields = List(FieldName(Item, "color"), FieldName(Item, "brand")))
+    )
   }
 
   it should "emit writes on meta field" in {

--- a/src/test/scala/ai/metarank/feature/InteractionCountTest.scala
+++ b/src/test/scala/ai/metarank/feature/InteractionCountTest.scala
@@ -25,22 +25,22 @@ class InteractionCountTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "emit item increments on type match" in {
     val event = TestInteractionEvent("e1", "e0").copy(`type` = "click", item = ItemId("p1"))
-    val write = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val write = feature.writes(event).unsafeRunSync().toList
     write shouldBe List(
       Increment(Key(ItemScope(ItemId("p1")), FeatureName("cnt")), event.timestamp, 1)
     )
   }
 
   it should "ignore non-interaction events" in {
-    feature.writes(TestItemEvent("p1"), Persistence.blackhole()).unsafeRunSync() shouldBe Nil
-    feature.writes(TestRankingEvent(List("p1")), Persistence.blackhole()).unsafeRunSync() shouldBe Nil
+    feature.writes(TestItemEvent("p1")).unsafeRunSync() shouldBe Nil
+    feature.writes(TestRankingEvent(List("p1"))).unsafeRunSync() shouldBe Nil
   }
 
   it should "also increment on session key" in {
     val sf = InteractionCountFeature(feature.schema.copy(scope = SessionScopeType))
     val event =
       TestInteractionEvent("e1", "e0").copy(`type` = "click", item = ItemId("p1"), session = Some(SessionId("s1")))
-    val write = sf.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val write = sf.writes(event).unsafeRunSync().toList
     write shouldBe List(
       Increment(Key(SessionScope(SessionId("s1")), FeatureName("cnt")), event.timestamp, 1)
     )

--- a/src/test/scala/ai/metarank/feature/ItemAgeFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/ItemAgeFeatureTest.scala
@@ -32,7 +32,7 @@ class ItemAgeFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       List(StringField("updated_at", updatedAt.format(DateTimeFormatter.ISO_DATE_TIME)))
     ).copy(timestamp = Timestamp(updatedAt.toInstant.toEpochMilli))
 
-    val puts = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val puts = feature.writes(event).unsafeRunSync().toList
     puts shouldBe List(
       Put(
         Key(ItemScope(ItemId("p1")), FeatureName("itemage")),
@@ -48,7 +48,7 @@ class ItemAgeFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       List(NumberField("updated_at", updatedAt.toEpochSecond.toDouble))
     ).copy(timestamp = Timestamp(updatedAt.toInstant.toEpochMilli))
 
-    val puts = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val puts = feature.writes(event).unsafeRunSync().toList
     puts shouldBe List(
       Put(
         Key(ItemScope(ItemId("p1")), FeatureName("itemage")),
@@ -64,7 +64,7 @@ class ItemAgeFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       List(StringField("updated_at", updatedAt.toEpochSecond.toString))
     ).copy(timestamp = Timestamp(updatedAt.toInstant.toEpochMilli))
 
-    val puts = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val puts = feature.writes(event).unsafeRunSync().toList
     puts shouldBe List(
       Put(
         Key(ItemScope(ItemId("p1")), FeatureName("itemage")),

--- a/src/test/scala/ai/metarank/feature/NormRateFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/NormRateFeatureTest.scala
@@ -42,17 +42,17 @@ class NormRateFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract writes" in {
     val click = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "click")
-    feature.writes(click, Persistence.blackhole()).unsafeRunSync().toList shouldBe List(
+    feature.writes(click).unsafeRunSync().toList shouldBe List(
       PeriodicIncrement(Key(ItemScope(ItemId("p1")), FeatureName("ctr_click")), click.timestamp, 1),
       PeriodicIncrement(Key(GlobalScope, FeatureName("ctr_click_norm")), click.timestamp, 1)
     )
     val impression = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "impression")
-    feature.writes(impression, Persistence.blackhole()).unsafeRunSync().toList shouldBe List(
+    feature.writes(impression).unsafeRunSync().toList shouldBe List(
       PeriodicIncrement(Key(ItemScope(ItemId("p1")), FeatureName("ctr_impression")), impression.timestamp, 1),
       PeriodicIncrement(Key(GlobalScope, FeatureName("ctr_impression_norm")), impression.timestamp, 1)
     )
     val dummy = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "dummy")
-    feature.writes(dummy, Persistence.blackhole()).unsafeRunSync().toList shouldBe empty
+    feature.writes(dummy).unsafeRunSync().toList shouldBe empty
   }
 
   it should "compute value" in {

--- a/src/test/scala/ai/metarank/feature/NumVectorFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/NumVectorFeatureTest.scala
@@ -60,7 +60,7 @@ class NumVectorFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract field from metadata with default reducers" in {
     val event  = TestItemEvent("p1", List(NumberListField("vec", List(1.0, 2.0, 3.0))))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(Key(ItemScope(ItemId("p1")), FeatureName("vec")), event.timestamp, SDoubleList(List(1.0, 3.0, 3.0, 2.0)))
     )

--- a/src/test/scala/ai/metarank/feature/NumberFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/NumberFeatureTest.scala
@@ -39,7 +39,7 @@ class NumberFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract field from metadata" in {
     val event  = TestItemEvent("p1", List(NumberField("popularity", 100)))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(Key(ItemScope(ItemId("p1")), FeatureName("popularity")), event.timestamp, SDouble(100))
     )
@@ -55,7 +55,7 @@ class NumberFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
     )
 
     val event  = TestInteractionEvent("p1", "k1", List(NumberField("popularity", 100))).copy(`type` = "click")
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(Key(ItemScope(ItemId("p1")), FeatureName("popularity")), event.timestamp, SDouble(100))
     )
@@ -71,7 +71,7 @@ class NumberFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
     )
 
     val event  = TestUserEvent("u1", List(NumberField("age", 33)))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(Key(UserScope(UserId("u1")), FeatureName("user_age")), event.timestamp, SDouble(33))
     )

--- a/src/test/scala/ai/metarank/feature/RateFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/RateFeatureTest.scala
@@ -29,11 +29,11 @@ class RateFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract writes" in {
     val click = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "click")
-    feature.writes(click, Persistence.blackhole()).unsafeRunSync().toList shouldBe List(
+    feature.writes(click).unsafeRunSync().toList shouldBe List(
       PeriodicIncrement(Key(ItemScope(ItemId("p1")), FeatureName("ctr_click")), click.timestamp, 1)
     )
     val impression = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "impression")
-    feature.writes(impression, Persistence.blackhole()).unsafeRunSync().toList shouldBe List(
+    feature.writes(impression).unsafeRunSync().toList shouldBe List(
       PeriodicIncrement(
         Key(ItemScope(ItemId("p1")), FeatureName("ctr_impression")),
         impression.timestamp,
@@ -41,7 +41,7 @@ class RateFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       )
     )
     val dummy = TestInteractionEvent("p1", "i1", Nil).copy(`type` = "dummy")
-    feature.writes(dummy, Persistence.blackhole()).unsafeRunSync().toList shouldBe empty
+    feature.writes(dummy).unsafeRunSync().toList shouldBe empty
   }
 
   it should "compute value" in {

--- a/src/test/scala/ai/metarank/feature/RefererFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/RefererFeatureTest.scala
@@ -29,7 +29,7 @@ class RefererFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
     TestRankingEvent(List("p1")).copy(user = UserId("u1"), fields = List(StringField("ref", "http://www.google.com")))
 
   it should "extract referer field" in {
-    val write = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val write = feature.writes(event).unsafeRunSync().toList
     write shouldBe List(
       Put(Key(UserScope(UserId("u1")), FeatureName("ref_medium")), event.timestamp, SString("search"))
     )

--- a/src/test/scala/ai/metarank/feature/StringFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/StringFeatureTest.scala
@@ -32,7 +32,7 @@ class StringFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract item field" in {
     val event  = TestItemEvent("p1", List(StringField("color", "green")))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(
         Key(ItemScope(ItemId("p1")), FeatureName("color")),
@@ -52,7 +52,7 @@ class StringFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
       )
     )
     val event  = TestUserEvent("u1", List(StringField("gender", "male")))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(
         Key(UserScope(UserId("u1")), FeatureName("user_gender")),

--- a/src/test/scala/ai/metarank/feature/WindowInteractionCountFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/WindowInteractionCountFeatureTest.scala
@@ -30,15 +30,15 @@ class WindowInteractionCountFeatureTest extends AnyFlatSpec with Matchers with F
 
   it should "count item clicks" in {
     val event = TestInteractionEvent("e1", "e0").copy(`type` = "click", item = ItemId("p1"))
-    val write = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val write = feature.writes(event).unsafeRunSync().toList
     write shouldBe List(
       PeriodicIncrement(Key(ItemScope(ItemId("p1")), FeatureName("cnt")), event.timestamp, 1)
     )
   }
 
   it should "ignore non-interaction events" in {
-    feature.writes(TestItemEvent("p1"), Persistence.blackhole()).unsafeRunSync().toList shouldBe Nil
-    feature.writes(TestRankingEvent(List("p1")), Persistence.blackhole()).unsafeRunSync().toList shouldBe Nil
+    feature.writes(TestItemEvent("p1")).unsafeRunSync().toList shouldBe Nil
+    feature.writes(TestRankingEvent(List("p1"))).unsafeRunSync().toList shouldBe Nil
   }
 
   it should "compute values" in {

--- a/src/test/scala/ai/metarank/feature/WordCountFeatureTest.scala
+++ b/src/test/scala/ai/metarank/feature/WordCountFeatureTest.scala
@@ -36,7 +36,7 @@ class WordCountFeatureTest extends AnyFlatSpec with Matchers with FeatureTest {
 
   it should "extract field" in {
     val event  = TestItemEvent("p1", List(StringField("title", "foo, bar, baz!")))
-    val result = feature.writes(event, Persistence.blackhole()).unsafeRunSync().toList
+    val result = feature.writes(event).unsafeRunSync().toList
     result shouldBe List(
       Put(Key(ItemScope(ItemId("p1")), FeatureName("title_words")), event.timestamp, SDouble(3))
     )

--- a/src/test/scala/ai/metarank/flow/ClickthroughQueryTest.scala
+++ b/src/test/scala/ai/metarank/flow/ClickthroughQueryTest.scala
@@ -35,7 +35,7 @@ class ClickthroughQueryTest extends AnyFlatSpec with Matchers {
     InteractedWithSchema(
       FeatureName("clicked_category"),
       "click",
-      FieldName(Item, "category"),
+      List(FieldName(Item, "category")),
       SessionScopeType,
       Some(10),
       Some(24.hours)

--- a/src/test/scala/ai/metarank/flow/ClickthroughQueryTest.scala
+++ b/src/test/scala/ai/metarank/flow/ClickthroughQueryTest.scala
@@ -9,6 +9,7 @@ import ai.metarank.feature.RateFeature.RateFeatureSchema
 import ai.metarank.feature.StringFeature.EncoderName.IndexEncoderName
 import ai.metarank.feature.StringFeature.StringFeatureSchema
 import ai.metarank.model.Clickthrough.TypedInteraction
+import ai.metarank.model.Dimension.VectorDim
 import ai.metarank.model.FieldName.EventType.Item
 import ai.metarank.model.Identifier.{ItemId, UserId}
 import ai.metarank.model.Key.FeatureName
@@ -69,7 +70,7 @@ class ClickthroughQueryTest extends AnyFlatSpec with Matchers {
             CategoryValue(FeatureName("category"), "socks", 1),
             VectorValue(FeatureName("ctr"), Array(0.2, 0.1), 2),
             SingleValue(FeatureName("price"), 10.0),
-            SingleValue(FeatureName("clicked_category"), 1)
+            VectorValue(FeatureName("clicked_category"), Array(1.0), VectorDim(1))
           )
         ),
         ItemValue(
@@ -78,14 +79,14 @@ class ClickthroughQueryTest extends AnyFlatSpec with Matchers {
             SingleValue(FeatureName("price"), 5.0),
             VectorValue(FeatureName("ctr"), Array(0.1, 0.05), 2),
             CategoryValue(FeatureName("category"), "shirts", 2),
-            SingleValue(FeatureName("clicked_category"), 0)
+            VectorValue(FeatureName("clicked_category"), Array(0.0), VectorDim(1))
           )
         ),
         ItemValue(
           ItemId("p3"),
           List(
             VectorValue(FeatureName("ctr"), Array(0.2, 0.2), 2),
-            SingleValue(FeatureName("clicked_category"), 1),
+            VectorValue(FeatureName("clicked_category"), Array(1.0), VectorDim(1)),
             SingleValue(FeatureName("price"), 3.0),
             CategoryValue(FeatureName("category"), "socks", 1)
           )

--- a/src/test/scala/ai/metarank/flow/MetarankFlowTest.scala
+++ b/src/test/scala/ai/metarank/flow/MetarankFlowTest.scala
@@ -55,7 +55,7 @@ class MetarankFlowTest extends AnyFlatSpec with Matchers {
     InteractedWithSchema(
       FeatureName("liked_genre"),
       "click",
-      FieldName(Item, "genre"),
+      List(FieldName(Item, "genre")),
       SessionScopeType,
       count = Some(10),
       duration = Some(24.hours)

--- a/src/test/scala/ai/metarank/flow/MetarankFlowTest.scala
+++ b/src/test/scala/ai/metarank/flow/MetarankFlowTest.scala
@@ -115,9 +115,9 @@ class MetarankFlowTest extends AnyFlatSpec with Matchers {
   it should "generate query for a ranking request" in {
     val q = ranker.makeQuery(rankingEvent1, mapping.models("random").datasetDescriptor).unsafeRunSync()
     q.values shouldBe List(
-      ItemValue(ItemId("p1"), List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", 0))),
-      ItemValue(ItemId("p2"), List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", 0))),
-      ItemValue(ItemId("p3"), List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", 0)))
+      ItemValue(ItemId("p1"), List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", Array(0.0)))),
+      ItemValue(ItemId("p2"), List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", Array(0.0)))),
+      ItemValue(ItemId("p3"), List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", Array(0.0))))
     )
     q.query.values.toList shouldBe List(
       10.0, 1.0, 0.0, // p1
@@ -133,9 +133,9 @@ class MetarankFlowTest extends AnyFlatSpec with Matchers {
   it should "generate updated query" in {
     val q = ranker.makeQuery(rankingEvent2, mapping.models("random").datasetDescriptor).unsafeRunSync()
     q.values shouldBe List(
-      ItemValue(ItemId("p1"), List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", 0))),
-      ItemValue(ItemId("p2"), List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", 1))),
-      ItemValue(ItemId("p3"), List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", 0)))
+      ItemValue(ItemId("p1"), List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", Array(0.0)))),
+      ItemValue(ItemId("p2"), List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", Array(1.0)))),
+      ItemValue(ItemId("p3"), List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", Array(0.0))))
     )
     q.query.values.toList shouldBe List(
       10.0, 1.0, 0.0, // p1
@@ -159,9 +159,18 @@ class MetarankFlowTest extends AnyFlatSpec with Matchers {
           interactions = List(TypedInteraction(ItemId("p1"), "click"))
         ),
         values = List(
-          ItemValue(ItemId("p1"), List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", 0))),
-          ItemValue(ItemId("p2"), List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", 1))),
-          ItemValue(ItemId("p3"), List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", 0)))
+          ItemValue(
+            ItemId("p1"),
+            List(MValue("pop", 10), MValue("genre", "action", 1), MValue("liked_genre", Array(0.0)))
+          ),
+          ItemValue(
+            ItemId("p2"),
+            List(MValue("pop", 5), MValue("genre", "comedy", 3), MValue("liked_genre", Array(1.0)))
+          ),
+          ItemValue(
+            ItemId("p3"),
+            List(MValue("pop", 15), MValue("genre", "drama", 2), MValue("liked_genre", Array(0.0)))
+          )
         )
       )
     )

--- a/src/test/scala/ai/metarank/main/autofeature/rule/InteractedWithFeatureRuleTest.scala
+++ b/src/test/scala/ai/metarank/main/autofeature/rule/InteractedWithFeatureRuleTest.scala
@@ -12,9 +12,9 @@ import org.scalatest.matchers.should.Matchers
 
 class InteractedWithFeatureRuleTest extends AnyFlatSpec with Matchers {
   it should "generate interacted_with for cats and ints" in {
-    val result = InteractedWithFeatureRule.make("click", "good")
+    val result = InteractedWithFeatureRule.make("click", List("good"))
     result shouldBe InteractedWithSchema(
-      name = FeatureName("click_good"),
+      name = FeatureName("click"),
       interaction = "click",
       fields = List(FieldName(Item, "good")),
       scope = UserScopeType,

--- a/src/test/scala/ai/metarank/main/autofeature/rule/InteractedWithFeatureRuleTest.scala
+++ b/src/test/scala/ai/metarank/main/autofeature/rule/InteractedWithFeatureRuleTest.scala
@@ -16,7 +16,7 @@ class InteractedWithFeatureRuleTest extends AnyFlatSpec with Matchers {
     result shouldBe InteractedWithSchema(
       name = FeatureName("click_good"),
       interaction = "click",
-      field = FieldName(Item, "good"),
+      fields = List(FieldName(Item, "good")),
       scope = UserScopeType,
       count = None,
       duration = None

--- a/src/test/scala/ai/metarank/util/TestFeatureMapping.scala
+++ b/src/test/scala/ai/metarank/util/TestFeatureMapping.scala
@@ -33,7 +33,7 @@ object TestFeatureMapping {
       InteractedWithSchema(
         FeatureName("clicked_category"),
         "click",
-        FieldName(Item, "category"),
+        List(FieldName(Item, "category")),
         SessionScopeType,
         Some(10),
         Some(24.hours)


### PR DESCRIPTION
It also changes the way feature state is stored:
* instead of doing heavy denormalization on writes (so we tracked all colors user clicked, for example), we now store only item ids of interacted items.
* we need to perform more work on inference stage (more computations and two redis hops), so latency will be probably impacted
* memory usage for the state (on a test ranklens dataset) went 4x down for feature values, and 10x for feature state. import performance also went up 2x.