### PR TITLE
cat-threshold cli arg

### DIFF
--- a/doc/howto/autofeature.md
+++ b/doc/howto/autofeature.md
@@ -31,6 +31,8 @@ Subcommand: autofeature - generate reference config based on existing data
       --out  <arg>       path to an output config file
   -r, --ruleset  <arg>   set of rules to generate config: stable, all (optional,
                          default=stable, values: [stable, all])
+  -c, --cat-threshold  <arg>   min threshold of category frequency, when its
+                               considered a catergory (optional, default=0.003)
   -h, --help             Show help message
 
 For all other tricks, consult the docs on https://docs.metarank.ai
@@ -108,6 +110,11 @@ So movie genres field is a good candidate for this type of heuristic due to its 
   - family
   - horror
 ```
+
+If you have a lot of distinct categories, and Metarank does not pick them up (e.g. decides that a category is too infrequent, and you get much less possible categories than expected), you can lower the category frequency threshold with a `--cat-threshold` flag.
+
+The default `--cat-threshold` value of 0.003 means that only categories with frequencies above 0.3% are included.
+
 * **InteractedWith**: all interaction over low-cardinality fields are translated to [interacted_with](../configuration/features/user-session.md#interacted-with) feature.
 So if a user clicked on an item with horror genre, other horror movies may get extra points:
 ```yaml

--- a/src/main/scala/ai/metarank/main/command/AutoFeature.scala
+++ b/src/main/scala/ai/metarank/main/command/AutoFeature.scala
@@ -20,7 +20,7 @@ object AutoFeature extends Logging {
   def run(args: AutoFeatureArgs): IO[Unit] = for {
     _      <- info("Generating config file")
     source <- IO(FileEventSource(FileInputConfig(args.data.toString, args.offset, args.format)).stream)
-    conf   <- run(source, args.rules)
+    conf   <- run(source, args.rules.create(args))
     yaml   <- IO(yamlFormat.pretty(conf.asJson))
   } yield {
     val file   = args.out.toFile

--- a/src/main/scala/ai/metarank/main/command/autofeature/rules/RuleSet.scala
+++ b/src/main/scala/ai/metarank/main/command/autofeature/rules/RuleSet.scala
@@ -1,27 +1,41 @@
 package ai.metarank.main.command.autofeature.rules
 
+import ai.metarank.main.CliArgs.AutoFeatureArgs
+
 case class RuleSet(rules: List[FeatureRule])
 
 object RuleSet {
-  def stable(): RuleSet = new RuleSet(
+  def stable(args: AutoFeatureArgs): RuleSet = new RuleSet(
     List(
       InteractedWithFeatureRule,
       NumericalFeatureRule,
-      StringFeatureRule(percentile = 0.90),
+      StringFeatureRule(percentile = 0.90, countThreshold = args.catThreshold),
       RelevancyRule,
       VectorFeatureRule
     )
   )
 
-  def all(): RuleSet = new RuleSet(
+  def all(args: AutoFeatureArgs): RuleSet = new RuleSet(
     List(
       InteractedWithFeatureRule,
       NumericalFeatureRule,
-      StringFeatureRule(minValues = 20, percentile = 0.95),
+      StringFeatureRule(minValues = 20, percentile = 0.95, countThreshold = args.catThreshold),
       RelevancyRule,
       VectorFeatureRule,
       InteractionRateFeatureRule,
       InteractionCountFeatureRule
     )
   )
+
+  sealed trait RuleSetType {
+    def create(args: AutoFeatureArgs): RuleSet
+  }
+  object RuleSetType {
+    case object StableRuleSet extends RuleSetType {
+      override def create(args: AutoFeatureArgs): RuleSet = stable(args)
+    }
+    case object AllRuleSet extends RuleSetType {
+      override def create(args: AutoFeatureArgs): RuleSet = all(args)
+    }
+  }
 }

--- a/src/main/scala/ai/metarank/main/command/autofeature/rules/StringFeatureRule.scala
+++ b/src/main/scala/ai/metarank/main/command/autofeature/rules/StringFeatureRule.scala
@@ -23,7 +23,7 @@ case class StringFeatureRule(
   }
 
   def fieldValues(stat: StringFieldStat): List[String] = {
-    val sorted         = stat.values.filter(_._2 > 3).toList.sortBy(-_._2)
+    val sorted         = stat.values.filter(_._2 >= 3).toList.sortBy(-_._2)
     val total          = sorted.map(_._2.toLong).sum
     val totalThreshold = percentile * total
     val itemThreshold  = countThreshold * total

--- a/src/main/scala/ai/metarank/main/command/autofeature/rules/StringFeatureRule.scala
+++ b/src/main/scala/ai/metarank/main/command/autofeature/rules/StringFeatureRule.scala
@@ -14,7 +14,7 @@ case class StringFeatureRule(
     minValues: Int = 10,
     maxValues: Int = 100,
     percentile: Double = 0.90,
-    countThreshold: Double = 0.01
+    countThreshold: Double = 0.003
 ) extends FeatureRule
     with Logging {
 
@@ -23,7 +23,7 @@ case class StringFeatureRule(
   }
 
   def fieldValues(stat: StringFieldStat): List[String] = {
-    val sorted         = stat.values.toList.sortBy(-_._2)
+    val sorted         = stat.values.filter(_._2 > 3).toList.sortBy(-_._2)
     val total          = sorted.map(_._2.toLong).sum
     val totalThreshold = percentile * total
     val itemThreshold  = countThreshold * total

--- a/src/test/scala/ai/metarank/main/AutofeatureTest.scala
+++ b/src/test/scala/ai/metarank/main/AutofeatureTest.scala
@@ -18,6 +18,6 @@ class AutofeatureTest extends AnyFlatSpec with Matchers {
   it should "generate test config for ranklens" in {
     val args   = AutoFeatureArgs(Paths.get("/tmp"), Paths.get("/tmp"))
     val result = AutoFeature.run(Stream.emits(RanklensEvents()), RuleSet.stable(args)).unsafeRunSync()
-    result.features.size shouldBe 8
+    result.features.size shouldBe 12
   }
 }

--- a/src/test/scala/ai/metarank/main/AutofeatureTest.scala
+++ b/src/test/scala/ai/metarank/main/AutofeatureTest.scala
@@ -3,6 +3,7 @@ package ai.metarank.main
 import ai.metarank.main.CliArgs.AutoFeatureArgs
 import ai.metarank.main.command.AutoFeature
 import ai.metarank.main.command.autofeature.rules.RuleSet
+import ai.metarank.main.command.autofeature.rules.RuleSet.RuleSetType.StableRuleSet
 import ai.metarank.model.Event
 import ai.metarank.util.RanklensEvents
 import cats.effect.IO
@@ -15,7 +16,8 @@ import java.nio.file.Paths
 
 class AutofeatureTest extends AnyFlatSpec with Matchers {
   it should "generate test config for ranklens" in {
-    val result = AutoFeature.run(Stream.emits(RanklensEvents()), RuleSet.stable()).unsafeRunSync()
-    val br     = 1
+    val args   = AutoFeatureArgs(Paths.get("/tmp"), Paths.get("/tmp"))
+    val result = AutoFeature.run(Stream.emits(RanklensEvents()), RuleSet.stable(args)).unsafeRunSync()
+    result.features.size shouldBe 8
   }
 }

--- a/src/test/scala/ai/metarank/main/autofeature/rule/StringFeatureRuleTest.scala
+++ b/src/test/scala/ai/metarank/main/autofeature/rule/StringFeatureRuleTest.scala
@@ -33,7 +33,7 @@ class StringFeatureRuleTest extends AnyFlatSpec with Matchers {
   }
 
   it should "not drop infreq values for low-cardinality fields" in {
-    val result = StringFeatureRule().make("color", StringFieldStat(Map("red" -> 10, "green" -> 1, "blue" -> 1)))
+    val result = StringFeatureRule().make("color", StringFieldStat(Map("red" -> 10, "green" -> 3, "blue" -> 3)))
     result shouldBe Some(
       StringFeatureSchema(
         name = FeatureName("color"),
@@ -54,7 +54,7 @@ class StringFeatureRuleTest extends AnyFlatSpec with Matchers {
         source = FieldName(Item, "color"),
         scope = ItemScopeType,
         encode = Some(IndexEncoderName),
-        values = NonEmptyList.of("c19", "c18", "c17", "c16", "c15", "c14", "c13", "c12", "c11", "c10", "c9", "c8", "c7")
+        values = NonEmptyList.of("c19", "c18", "c17", "c16", "c15", "c14", "c13", "c12", "c11", "c10", "c9", "c8")
       )
     )
   }


### PR DESCRIPTION
So you can control the amount of categories in the autofeature string category generator rule. As sometimes there's not that many of them.