### PR TITLE
linux/aarch64 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val root = (project in file("."))
       "org.http4s"            %% "http4s-blaze-server"      % http4sVersion,
       "org.http4s"            %% "http4s-blaze-client"      % http4sVersion,
       "org.http4s"            %% "http4s-circe"             % http4sVersion,
-      "io.github.metarank"    %% "ltrlib"                   % "0.1.17",
+      "io.github.metarank"    %% "ltrlib"                   % "0.1.18",
       "com.github.ua-parser"   % "uap-java"                 % "1.5.3",
       "com.snowplowanalytics" %% "scala-referer-parser"     % "2.0.0",
       "org.apache.lucene"      % "lucene-core"              % luceneVersion,


### PR DESCRIPTION
fixes https://github.com/metarank/metarank/issues/743

Both lightgbm+xgboost seem to be working fine on a EC2 graviton instance:

```
11:49:58.800 INFO  ai.metarank.main.command.Train$ - generated training dataset: 8773 groups, 29 dims
11:49:58.807 INFO  ai.metarank.main.command.Train$ - training model for train=7002 test=1771
Loading native lib linux/aarch64/lib_lightgbm.so
Extracting native lib /tmp/lib_lightgbm.so
Copied 4625288 bytes
Extracted file: exists=true path=/tmp/lib_lightgbm.so
Loading native lib linux/aarch64/lib_lightgbm_swig.so
Extracting native lib /tmp/lib_lightgbm_swig.so
Copied 141344 bytes
Extracted file: exists=true path=/tmp/lib_lightgbm_swig.so
[LightGBM] [Warning] Auto-choosing row-wise multi-threading, the overhead of testing was 0.030400 seconds.
You can set `force_row_wise=true` to remove the overhead.
And if memory is not enough, you can set `force_col_wise=true`.
[LightGBM] [Info] Total Bins 1917
[LightGBM] [Info] Number of data points in the train set: 168048, number of used features: 29
11:49:59.679 INFO  i.g.m.l.ranking.pairwise.LambdaMART - [0] NDCG@train = 0.47286489574407314 NDCG@test = 0.46696781479390176
11:49:59.706 INFO  i.g.m.l.ranking.pairwise.LambdaMART - [1] NDCG@train = 0.4975721222507855 NDCG@test = 0.4991530208921513
11:49:59.733 INFO  i.g.m.l.ranking.pairwise.LambdaMART - [2] NDCG@train = 0.5091402456441017 NDCG@test = 0.5064935064935064
11:49:59.759 INFO  i.g.m.l.ranking.pairwise.LambdaMART - [3] NDCG@train = 0.5109968580405598 NDCG@test = 0.5076228119706381
11:49:59.786 INFO  i.g.m.l.ranking.pairwise.LambdaMART - [4] NDCG@train = 0.5157097972007998 NDCG@test = 0.5110107284020328
```