### PR TITLE
make pathExists validation error message less cryptic

### DIFF
--- a/src/main/scala/ai/metarank/main/CliArgs.scala
+++ b/src/main/scala/ai/metarank/main/CliArgs.scala
@@ -314,15 +314,17 @@ object CliArgs extends Logging {
     def pathExists(path: Path) = {
       val result = path.toFile.exists()
       if (!result) {
-        logger.error(s"Path $path does not exist")
         for {
           parent <- Option(path.getParent) if parent.toFile.isDirectory
         } {
           val dir = parent.toFile
           if (!dir.exists()) {
-            logger.error(s"parent dir $dir also does not exist. Maybe you're using a wrong path?")
+            throw new Exception(
+              s"Path $path does not exist. Parent dir $dir is also missing. Maybe you're using a wrong path?"
+            )
           } else {
-            logger.info(s"parent dir $dir has these files: ${dir.listFiles().toList.map(_.getName)}")
+            val files = dir.listFiles().toList.map(_.toString).mkString("\n - ", "\n - ", "\n")
+            throw new Exception(s"Path $path does not exist, but these files do:\n $files")
           }
         }
       }


### PR DESCRIPTION
fixes https://github.com/metarank/metarank/issues/742

Now it prints something like this:
```
java.lang.Exception: Path src/test/resources/ranklens/config.yml2 does not exist, but these files do:
 
 - src/test/resources/ranklens/config.yml
 - src/test/resources/ranklens/events
 - src/test/resources/ranklens/ranklens.model
```