### PR TITLE
fix issue with cts file being overwritten

### DIFF
--- a/src/main/scala/ai/metarank/fstore/clickthrough/FileClickthroughStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/FileClickthroughStore.scala
@@ -60,7 +60,7 @@ object FileClickthroughStore {
 
   def create(path: String, fmt: StoreFormat): Resource[IO, FileClickthroughStore] = for {
     file <- Resource.liftK(IO { new File(path) })
-    stream <- Resource.make(IO { new BufferedOutputStream(new FileOutputStream(file), FILE_BUFFER_SIZE) })(stream =>
+    stream <- Resource.make(IO { new BufferedOutputStream(new FileOutputStream(file, true), FILE_BUFFER_SIZE) })(stream =>
       IO(stream.close())
     )
   } yield {

--- a/src/test/scala/ai/metarank/fstore/clickthrough/FileClickthroughStoreTest.scala
+++ b/src/test/scala/ai/metarank/fstore/clickthrough/FileClickthroughStoreTest.scala
@@ -10,14 +10,23 @@ import java.nio.file.Files
 class FileClickthroughStoreTest extends AnyFlatSpec with Matchers {
   val ctv = TestClickthroughValues()
 
-  it should "write+read cts" in {
-    val path = Files.createTempFile("cts", ".dat").toString
+  lazy val path = Files.createTempFile("cts", ".dat").toString
+
+  it should "write cts" in {
     val (store, close) = FileClickthroughStore
       .create(path, BinaryStoreFormat)
       .allocated
       .unsafeRunSync()
     store.put(List(ctv, ctv, ctv)).unsafeRunSync()
     store.flush().unsafeRunSync()
+    close.unsafeRunSync()
+  }
+
+  it should "write+read cts" in {
+    val (store, close) = FileClickthroughStore
+      .create(path, BinaryStoreFormat)
+      .allocated
+      .unsafeRunSync()
     val read = store.getall().compile.toList.unsafeRunSync()
     read shouldBe List(ctv, ctv, ctv)
     close.unsafeRunSync()


### PR DESCRIPTION
Looks like that click-through store local file is being over-written (and reset) on Metarank restart. When we open OutputStream, we don't mark it with `append=true`, so it resets it.