### PR TITLE
expose JVM_OPTS to env

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,9 +2,9 @@ name: Integration tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 0.5.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 0.5.x ]
 env:
   AWS_ACCESS_KEY_ID: foo
   AWS_SECRET_ACCESS_KEY: bar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 0.5.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 0.5.x ]
 
 env:
   METARANK_TRACKING: false

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -12,6 +12,8 @@ image:
 
 # Can be used to pass auth secrets as env variables
 env: []
+#  - name: JVM_OPTS
+#    value: "-Xmx1g -verbose:gc"
 #  - name: METARANK_REDIS_PASSWORD
 #    valueFrom:
 #      secretKeyRef:

--- a/deploy/metarank.sh
+++ b/deploy/metarank.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 set -euxo pipefail
-exec /usr/bin/java -jar /app/metarank.jar "$@"
+OPTS=${JAVA_OPTS:-"-Xmx1g -verbose:gc"}
+
+exec /usr/bin/java $OPTS -jar /app/metarank.jar "$@"
 

--- a/doc/deploy/docker.md
+++ b/doc/deploy/docker.md
@@ -33,6 +33,16 @@ For example, you can pass the input training dataset from your local host using 
 docker run -v /home/user/input:/data metarank/metarank:latest train <opts>
 ```
 
+#### Memory
+
+Metarank docker container uses 1Gb of JVM heap by default. In practice the actual RSS memory usage is a bit higher than the heap size due to JVM's extra overhead. 
+
+This can be configured with the `JVM_OPTS` environment variable:
+```shell
+docker run -e JVM_OPTS="-Xmx5g" metarank/metarank:latest train <opts>
+```
+
+
 ### Ports
 
 The image exposes the following ports:

--- a/doc/deploy/kubernetes.md
+++ b/doc/deploy/kubernetes.md
@@ -89,7 +89,7 @@ The Metarank docker container accepts a `JVM_OPTS` environment variable to contr
 * Enable verbose GC logging. You may notice the following lines in the log, they are normal:
 
 ```
-[282.621s][info][gc] GC(27) Pause Young (Allocation Failure) 55M->36M(67M) 2.718ms 
+[282.621s][info][gc] GC(26) Pause Young (Allocation Failure) 55M->36M(67M) 2.718ms 
 ```
 
 ## Installing the chart

--- a/doc/deploy/kubernetes.md
+++ b/doc/deploy/kubernetes.md
@@ -78,7 +78,19 @@ features:
     source: metadata.popularity
 ```
 
-The `values.yaml` is a generic helm deployment configuration file. You can tune it, but default one requires no extra changes. 
+The `values.yaml` is a generic helm deployment configuration file. You can tune it, but default one **usually** requires no extra changes.
+
+### Resources
+
+The default helm chart sets no specific memory requests & limits, but it can be configured with `values.yaml`. 
+
+The Metarank docker container accepts a `JVM_OPTS` environment variable to control the JVM memory usage. It defaults to `JVM_OPTS="-Xmx1g -verbose:gc"` which means:
+* Use 1Gb for JVM heap. The actual RSS memory usage should be a bit higher due to JVM extra overhead.
+* Enable verbose GC logging. You may notice the following lines in the log, they are normal:
+
+```
+[282.621s][info][gc] GC(27) Pause Young (Allocation Failure) 55M->36M(67M) 2.718ms 
+```
 
 ## Installing the chart
 


### PR DESCRIPTION
So users can control the actual JVM mem usage. We also explicitly set heap size to 1g by default.