### PR TITLE
fix empty-max crash

### DIFF
--- a/src/main/scala/ai/metarank/flow/ImpressionInject.scala
+++ b/src/main/scala/ai/metarank/flow/ImpressionInject.scala
@@ -14,21 +14,29 @@ import fs2.{Pipe, Stream}
 object ImpressionInject extends Logging {
 
   def process(ct: Clickthrough): List[InteractionEvent] = {
-    val positions   = ct.items.zipWithIndex.toMap
-    val maxPosition = ct.interactions.flatMap(i => positions.get(i.item)).max
-    ct.items
-      .take(maxPosition + 1)
-      .map(item =>
-        InteractionEvent(
-          id = ct.id,
-          item = item,
-          timestamp = ct.ts,
-          ranking = Some(ct.id),
-          user = ct.user,
-          session = ct.session,
-          `type` = "impression"
+    val positions = ct.items.zipWithIndex.toMap
+    ct.interactions.flatMap(i => positions.get(i.item)).maxOption match {
+      case None =>
+        logger.warn(
+          s"received interactions ${ct.interactions} over non-existent items ${ct.items}, parent ranking=${ct.id} user=${ct.user}"
         )
-      )
+        Nil
+      case Some(maxPosition) =>
+        ct.items
+          .take(maxPosition + 1)
+          .map(item =>
+            InteractionEvent(
+              id = ct.id,
+              item = item,
+              timestamp = ct.ts,
+              ranking = Some(ct.id),
+              user = ct.user,
+              session = ct.session,
+              `type` = "impression"
+            )
+          )
+
+    }
 
   }
 }

--- a/src/test/scala/ai/metarank/flow/ImpressionInjectTest.scala
+++ b/src/test/scala/ai/metarank/flow/ImpressionInjectTest.scala
@@ -20,6 +20,10 @@ class ImpressionInjectTest extends AnyFlatSpec with Matchers {
     val result = ImpressionInject.process(ct)
     result.map(_.item) shouldBe List(ItemId("p1"), ItemId("p2"))
   }
+  it should "not fail on wrong product in ctk" in {
+    val result = ImpressionInject.process(ct.copy(interactions = List(TypedInteraction(ItemId("p5"), "click"))))
+    result.map(_.item) shouldBe Nil
+  }
 
   it should "inject impressions on two clicks" in {
     val result = ImpressionInject.process(
@@ -31,6 +35,5 @@ class ImpressionInjectTest extends AnyFlatSpec with Matchers {
       )
     )
     result.map(_.item) shouldBe List(ItemId("p1"), ItemId("p2"), ItemId("p3"))
-
   }
 }


### PR DESCRIPTION
A fix for the following issue:
```
20:03:01.924 ERROR org.http4s.server.service-errors - Error servicing request: POST /feedback from 6.6.6.6
java.lang.UnsupportedOperationException: empty.max
	at scala.collection.IterableOnceOps.max(IterableOnce.scala:978)
	at scala.collection.IterableOnceOps.max$(IterableOnce.scala:976)
	at scala.collection.AbstractIterable.max(Iterable.scala:933)
	at ai.metarank.flow.ImpressionInject$.process(ImpressionInject.scala:18)
	at ai.metarank.flow.MetarankFlow$.$anonfun$process$16(MetarankFlow.scala:40)
	at scala.collection.immutable.List.flatMap(List.scala:293)
	at ai.metarank.flow.MetarankFlow$.$anonfun$process$15(MetarankFlow.scala:40)

```