### PR TITLE
fix crash on model load with unsupported bitstream error

### DIFF
--- a/src/main/scala/ai/metarank/fstore/redis/RedisModelStore.scala
+++ b/src/main/scala/ai/metarank/fstore/redis/RedisModelStore.scala
@@ -32,9 +32,14 @@ case class RedisModelStore(client: RedisClient, prefix: String)(implicit kc: KCo
           case Right(value) => IO(Some(value))
         }
       case Some(bytes) =>
-        pred.load(Some(bytes)) match {
-          case Left(error)  => IO.raiseError(error)
-          case Right(value) => IO(Some(value))
+        vc.decode(bytes) match {
+          case Left(err) => IO.raiseError(err)
+          case Right(decodedBytes) =>
+            pred.load(Some(decodedBytes)) match {
+              case Left(error)  => IO.raiseError(error)
+              case Right(value) => IO(Some(value))
+            }
+
         }
     }
   } yield {

--- a/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
+++ b/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
@@ -102,7 +102,8 @@ object LambdaMARTRanker {
               case 1     => Right(LambdaMARTModel(name, config, XGBoostBooster(buf)))
               case other => Left(new Exception(s"unsupported booster tag $other"))
             }
-          case Success(other) => Left(new Exception(s"unsupported bitstream version $other, please re-run train"))
+          case Success(other) =>
+            Left(new Exception(s"unsupported bitstream version $other, please re-run train"))
           case Failure(ex)    => Left(ex)
         }
     }

--- a/src/test/resources/ranklens/config.yml
+++ b/src/test/resources/ranklens/config.yml
@@ -1,11 +1,11 @@
-#state:
+state:
 #  type: file
 #  path: /tmp/lmdb4/
 #  backend: mapdb
-#  type: redis
-#  host: localhost
-#  port: 6379
-#  format: binary
+  type: redis
+  host: localhost
+  port: 6379
+  format: binary
 #train:
 #  type: file
 #  path: /tmp/nonexistent.dat
@@ -16,18 +16,18 @@ core:
     maxSessionLength: 60s
 
 models:
-  similar:
-    type: als
-    interactions: [click]
-    factors: 100
-    iterations: 100
-
-  trending:
-    type: trending
-    weights:
-      - interaction: click
-        decay: 1.0
-        weight: 1.0
+#  similar:
+#    type: als
+#    interactions: [click]
+#    factors: 100
+#    iterations: 100
+#
+#  trending:
+#    type: trending
+#    weights:
+#      - interaction: click
+#        decay: 1.0
+#        weight: 1.0
 
   xgboost:
     type: lambdamart

--- a/src/test/resources/ranklens/config.yml
+++ b/src/test/resources/ranklens/config.yml
@@ -1,11 +1,11 @@
-state:
+#state:
 #  type: file
 #  path: /tmp/lmdb4/
 #  backend: mapdb
-  type: redis
-  host: localhost
-  port: 6379
-  format: binary
+#  type: redis
+#  host: localhost
+#  port: 6379
+#  format: binary
 #train:
 #  type: file
 #  path: /tmp/nonexistent.dat
@@ -16,18 +16,18 @@ core:
     maxSessionLength: 60s
 
 models:
-#  similar:
-#    type: als
-#    interactions: [click]
-#    factors: 100
-#    iterations: 100
-#
-#  trending:
-#    type: trending
-#    weights:
-#      - interaction: click
-#        decay: 1.0
-#        weight: 1.0
+  similar:
+    type: als
+    interactions: [click]
+    factors: 100
+    iterations: 100
+
+  trending:
+    type: trending
+    weights:
+      - interaction: click
+        decay: 1.0
+        weight: 1.0
 
   xgboost:
     type: lambdamart

--- a/src/test/scala/ai/metarank/fstore/ModelStoreSuite.scala
+++ b/src/test/scala/ai/metarank/fstore/ModelStoreSuite.scala
@@ -1,0 +1,40 @@
+package ai.metarank.fstore
+
+import ai.metarank.config.BoosterConfig.XGBoostConfig
+import ai.metarank.fstore.Persistence.{ModelName, ModelStore}
+import ai.metarank.ml.rank.LambdaMARTRanker.{LambdaMARTConfig, LambdaMARTModel, LambdaMARTPredictor}
+import ai.metarank.ml.rank.ShuffleRanker.{ShuffleConfig, ShuffleModel, ShufflePredictor}
+import ai.metarank.model.Key.FeatureName
+import better.files.Resource
+import cats.data.NonEmptyList
+import cats.effect.unsafe.implicits.global
+import io.github.metarank.ltrlib.booster.{LightGBMBooster, XGBoostBooster}
+import io.github.metarank.ltrlib.model.DatasetDescriptor
+import io.github.metarank.ltrlib.model.Feature.SingularFeature
+import org.apache.commons.io.IOUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+trait ModelStoreSuite extends AnyFlatSpec with Matchers {
+  def store: ModelStore
+
+  val model = LambdaMARTModel(
+    "lgbm",
+    LambdaMARTConfig(
+      backend = XGBoostConfig(),
+      features = NonEmptyList.one(FeatureName("foo")),
+      weights = Map("click" -> 1)
+    ),
+    booster = LightGBMBooster.apply(IOUtils.toByteArray(Resource.my.getAsStream("/ranklens/ranklens.model")))
+  )
+
+  val predictor = LambdaMARTPredictor("lgbm", model.conf, DatasetDescriptor(List(SingularFeature("foo"))))
+
+  it should "put-get" in {
+    store.put(model).unsafeRunSync()
+    val read = store.get(ModelName("lgbm"), predictor).unsafeRunSync()
+    read.map(_.conf) shouldBe Some(model.conf)
+  }
+}

--- a/src/test/scala/ai/metarank/fstore/file/FileStatsEstimatorTest.scala
+++ b/src/test/scala/ai/metarank/fstore/file/FileStatsEstimatorTest.scala
@@ -10,6 +10,8 @@ import ai.metarank.util.TestKey
 import cats.effect.unsafe.implicits.global
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
+import scala.util.Random
+
 class FileStatsEstimatorTest extends StatsEstimatorSuite with FileTest with Eventually with IntegrationPatience {
   override def feature(config: StatsEstimatorConfig): FileStatsEstimatorFeature =
     FileStatsEstimatorFeature(config, db, "x", BinaryStoreFormat)
@@ -18,7 +20,7 @@ class FileStatsEstimatorTest extends StatsEstimatorSuite with FileTest with Even
     // may be probabilistic due to reservoir sampling in the FSE implementation
     eventually {
       val c = config.copy(name = FeatureName("sss"))
-      val f = feature(c)
+      val f = FileStatsEstimatorFeature(config, db, "x" + Random.nextInt(Int.MaxValue), BinaryStoreFormat)
       f.put(PutStatSample(TestKey(c, "a"), now, 1.0)).unsafeRunSync()
       f.put(PutStatSample(TestKey(c, "a"), now, 1.0)).unsafeRunSync()
       f.put(PutStatSample(TestKey(c, "a"), now, 1.0)).unsafeRunSync()

--- a/src/test/scala/ai/metarank/fstore/memory/MemModelStoreTest.scala
+++ b/src/test/scala/ai/metarank/fstore/memory/MemModelStoreTest.scala
@@ -1,0 +1,7 @@
+package ai.metarank.fstore.memory
+
+import ai.metarank.fstore.{ModelStoreSuite, Persistence}
+
+class MemModelStoreTest extends ModelStoreSuite {
+  override val store: Persistence.ModelStore = MemModelStore()
+}

--- a/src/test/scala/ai/metarank/fstore/redis/RedisModelStoreTest.scala
+++ b/src/test/scala/ai/metarank/fstore/redis/RedisModelStoreTest.scala
@@ -1,0 +1,10 @@
+package ai.metarank.fstore.redis
+
+import ai.metarank.fstore.codec.StoreFormat.BinaryStoreFormat
+import ai.metarank.fstore.redis.RedisPersistence.Prefix
+import ai.metarank.fstore.{ModelStoreSuite, Persistence}
+
+class RedisModelStoreTest extends ModelStoreSuite with RedisTest {
+  lazy val fmt                               = BinaryStoreFormat
+  override val store: Persistence.ModelStore = RedisModelStore(client, Prefix.MODELS)(fmt.modelName, fmt.model)
+}


### PR DESCRIPTION
A fix for:
```
java.lang.Exception: unsupported bitstream version -74, please re-run train
        at ai.metarank.ml.rank.LambdaMARTRanker$LambdaMARTPredictor.load(LambdaMARTRanker.scala:91)
        at ai.metarank.fstore.redis.RedisModelStore.$anonfun$get$1(RedisModelStore.scala:35)
        at map @ ai.metarank.fstore.redis.RedisModelStore.$anonfun$get$1(RedisModelStore.scala:28)
        at apply @ ai.metarank.fstore.redis.client.RedisClient.get(RedisClient.scala:57)
        at fromCompletableFuture @ ai.metarank.fstore.redis.RedisPersistence$.$anonfun$create$4(RedisPersistence.scala:169)
        at map @ ai.metarank.fstore.redis.client.RedisClient.get(RedisClient.scala:57)
        at flatMap @ ai.metarank.fstore.redis.RedisModelStore.get(RedisModelStore.scala:27)
        at apply @ ai.metarank.fstore.memory.MemModelStore.get(MemModelStore.scala:13)
        at flatMap @ ai.metarank.fstore.cache.CachedModelStore.get(CachedModelStore.scala:16)
        at flatMap @ ai.metarank.ml.Ranker.loadModel(Ranker.scala:73)
        at flatMap @ ai.metarank.ml.Ranker.$anonfun$rerank$3(Ranker.scala:35)
        at flatMap @ ai.metarank.ml.Ranker.$anonfun$rerank$2(Ranker.scala:29)
        at apply @ ai.metarank.ml.Ranker.rerank(Ranker.scala:28)
        at flatMap @ ai.metarank.ml.Ranker.rerank(Ranker.scala:28)
```

when running train after import