### PR TITLE
fix issue with ndcg mismatch in booster and eval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val root = (project in file("."))
       "org.http4s"            %% "http4s-blaze-server"      % http4sVersion,
       "org.http4s"            %% "http4s-blaze-client"      % http4sVersion,
       "org.http4s"            %% "http4s-circe"             % http4sVersion,
-      "io.github.metarank"    %% "ltrlib"                   % "0.2.0",
+      "io.github.metarank"    %% "ltrlib"                   % "0.2.2",
       "com.github.ua-parser"   % "uap-java"                 % "1.5.4",
       "com.snowplowanalytics" %% "scala-referer-parser"     % "2.0.0",
       "org.apache.lucene"      % "lucene-core"              % luceneVersion,

--- a/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
+++ b/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
@@ -51,11 +51,11 @@ object LambdaMARTRanker {
       _             <- checkDatasetSize(split.train)
       result        <- IO(makeBooster(split))
       model         <- IO.pure(LambdaMARTModel(name, config, result))
-      ndcg20        <- IO(model.eval(split.test, NDCG(20)))
+      ndcg20        <- IO(model.eval(split.test, NDCG(20, nolabels = 1.0)))
       _             <- info(s"NDCG20: source=${ndcg20.noopValue} reranked=${ndcg20.value} random=${ndcg20.randomValue}")
-      ndcg10        <- IO(model.eval(split.test, NDCG(10)))
+      ndcg10        <- IO(model.eval(split.test, NDCG(10, nolabels = 1.0)))
       _             <- info(s"NDCG10: source=${ndcg10.noopValue} reranked=${ndcg10.value} random=${ndcg10.randomValue}")
-      ndcg5         <- IO(model.eval(split.test, NDCG(5)))
+      ndcg5         <- IO(model.eval(split.test, NDCG(5, nolabels = 1.0)))
       _             <- info(s"NDCG5: source=${ndcg5.noopValue} reranked=${ndcg5.value} random=${ndcg5.randomValue}")
       mrr           <- IO(model.eval(split.test, MRR))
       _             <- info(s"MRR: source=${mrr.noopValue} reranked=${mrr.value} random=${mrr.randomValue}")
@@ -171,7 +171,6 @@ object LambdaMARTRanker {
     } yield {
       clickthroughs
     }
-
   }
 
   def checkDatasetSize(ds: Dataset): IO[Unit] =

--- a/src/test/scala/ai/metarank/util/TestQueryRequest.scala
+++ b/src/test/scala/ai/metarank/util/TestQueryRequest.scala
@@ -23,7 +23,7 @@ object TestQueryRequest {
       user = None,
       session = None,
       ts = Timestamp.now,
-      query = Query(0, labels, values, 1, n)
+      query = Query(0, labels, values)
     )
   }
 }


### PR DESCRIPTION
It was resulting in a sub-optimal training on all the boosters when dataset was not sorted by query-id - which is like almost always.