### PR TITLE
add field split strategy

### DIFF
--- a/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
+++ b/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
@@ -52,11 +52,11 @@ object LambdaMARTRanker {
       _             <- checkDatasetSize(split.train)
       result        <- IO(makeBooster(split))
       model         <- IO.pure(LambdaMARTModel(name, config, result))
-      ndcg20        <- IO(model.eval(split.test, NDCG(20, nolabels = 1.0)))
+      ndcg20        <- IO(model.eval(split.test, NDCG(20, nolabels = 1.0, relpow = true)))
       _             <- info(s"NDCG20: source=${ndcg20.noopValue} reranked=${ndcg20.value} random=${ndcg20.randomValue}")
-      ndcg10        <- IO(model.eval(split.test, NDCG(10, nolabels = 1.0)))
+      ndcg10        <- IO(model.eval(split.test, NDCG(10, nolabels = 1.0, relpow = true)))
       _             <- info(s"NDCG10: source=${ndcg10.noopValue} reranked=${ndcg10.value} random=${ndcg10.randomValue}")
-      ndcg5         <- IO(model.eval(split.test, NDCG(5, nolabels = 1.0)))
+      ndcg5         <- IO(model.eval(split.test, NDCG(5, nolabels = 1.0, relpow = true)))
       _             <- info(s"NDCG5: source=${ndcg5.noopValue} reranked=${ndcg5.value} random=${ndcg5.randomValue}")
       mrr           <- IO(model.eval(split.test, MRR))
       _             <- info(s"MRR: source=${mrr.noopValue} reranked=${mrr.value} random=${mrr.randomValue}")
@@ -164,7 +164,8 @@ object LambdaMARTRanker {
           QueryMetadata(
             query = ClickthroughQuery(ct.values, ct.ct.interactions, ct, config.weights, desc),
             ts = ct.ct.ts,
-            user = ct.ct.user
+            user = ct.ct.user,
+            fields = ct.ct.rankingFields
           )
         )
         .compile

--- a/src/main/scala/ai/metarank/model/QueryMetadata.scala
+++ b/src/main/scala/ai/metarank/model/QueryMetadata.scala
@@ -3,4 +3,4 @@ package ai.metarank.model
 import ai.metarank.model.Identifier.UserId
 import io.github.metarank.ltrlib.model.Query
 
-case class QueryMetadata(query: Query, ts: Timestamp, user: Option[UserId])
+case class QueryMetadata(query: Query, ts: Timestamp, user: Option[UserId], fields: List[Field])

--- a/src/test/scala/ai/metarank/main/SplitStrategyTest.scala
+++ b/src/test/scala/ai/metarank/main/SplitStrategyTest.scala
@@ -1,7 +1,8 @@
 package ai.metarank.main
 
 import ai.metarank.main.command.train.SplitStrategy
-import ai.metarank.main.command.train.SplitStrategy.{RandomSplit, TimeSplit}
+import ai.metarank.main.command.train.SplitStrategy.{FieldStrategy, RandomSplit, TimeSplit}
+import ai.metarank.model.Field.StringField
 import ai.metarank.model.{QueryMetadata, Timestamp}
 import cats.effect.unsafe.implicits.global
 import io.github.metarank.ltrlib.model.{DatasetDescriptor, LabeledItem, Query}
@@ -13,11 +14,12 @@ class SplitStrategyTest extends AnyFlatSpec with Matchers {
   it should "parse inputs" in {
     SplitStrategy.parse("random=10%") shouldBe Right(RandomSplit(10))
     SplitStrategy.parse("random") shouldBe Right(RandomSplit(80))
+    SplitStrategy.parse("field=split:train:test") shouldBe Right(FieldStrategy("split", "train", "test"))
   }
 
   val desc  = DatasetDescriptor(List(SingularFeature("foo")))
   val now   = Timestamp.now
-  val query = QueryMetadata(Query(desc, List(LabeledItem(1.0, 1, Array(1.0)))), now, None)
+  val query = QueryMetadata(Query(desc, List(LabeledItem(1.0, 1, Array(1.0)))), now, None, Nil)
 
   "time-split" should "handle unbalanced small inputs, size=2" in {
     val split = TimeSplit(80).split(desc, List(query, query)).unsafeRunSync()
@@ -29,5 +31,19 @@ class SplitStrategyTest extends AnyFlatSpec with Matchers {
     val split = TimeSplit(80).split(desc, List(query, query, query)).unsafeRunSync()
     split.test.groups.size shouldBe 1
     split.train.groups.size shouldBe 2
+  }
+
+  "field split" should "split by field value" in {
+    val result = FieldStrategy("split", "train", "test")
+      .split(
+        desc,
+        List(
+          query.copy(fields = List(StringField("split", "train"))),
+          query.copy(fields = List(StringField("split", "test")))
+        )
+      )
+      .unsafeRunSync()
+    result.test.groups.size shouldBe 1
+    result.train.groups.size shouldBe 1
   }
 }


### PR DESCRIPTION
So you can explicitly set which ranking goes to test and train.

Useful for the ESCI dataset.