### PR TITLE
support RFC4180 CSV double-quotes

### DIFF
--- a/src/main/scala/ai/metarank/util/CSVStream.scala
+++ b/src/main/scala/ai/metarank/util/CSVStream.scala
@@ -1,7 +1,7 @@
 package ai.metarank.util
 
 import cats.effect.{IO, Resource}
-import com.opencsv.{CSVParserBuilder, CSVReader, CSVReaderBuilder}
+import com.opencsv.{AbstractCSVParser, CSVParser, CSVParserBuilder, CSVReader, CSVReaderBuilder, RFC4180ParserBuilder}
 import fs2.Stream
 
 import scala.jdk.CollectionConverters._
@@ -9,15 +9,21 @@ import java.io.{File, FileInputStream, InputStream, InputStreamReader}
 
 object CSVStream extends Logging {
   val CHUNK_SIZE = 1024
-  def fromStream(stream: InputStream, delimiter: Char, skip: Int): Stream[IO, Array[String]] = for {
-    parser <- Stream.eval(IO(new CSVParserBuilder().withSeparator(delimiter).build()))
-    reader <- Stream.eval(
-      IO(new CSVReaderBuilder(new InputStreamReader(stream)).withCSVParser(parser).withSkipLines(skip).build())
-    )
-    rows <- Stream.fromBlockingIterator[IO](reader.iterator().asScala, CHUNK_SIZE)
-  } yield {
-    rows
+
+  def createParser(delimiter: Char, rfc4180: Boolean): IO[AbstractCSVParser] = IO {
+    if (rfc4180) new RFC4180ParserBuilder().withSeparator(delimiter).build()
+    else new CSVParserBuilder().withSeparator(delimiter).build()
   }
+  def fromStream(stream: InputStream, delimiter: Char, skip: Int, rfc4180: Boolean = true): Stream[IO, Array[String]] =
+    for {
+      parser <- Stream.eval(createParser(delimiter, rfc4180))
+      reader <- Stream.eval(
+        IO(new CSVReaderBuilder(new InputStreamReader(stream)).withCSVParser(parser).withSkipLines(skip).build())
+      )
+      rows <- Stream.fromBlockingIterator[IO](reader.iterator().asScala, CHUNK_SIZE)
+    } yield {
+      rows
+    }
 
   def fromFile(path: String, delimiter: Char, skip: Int): Stream[IO, Array[String]] = for {
     stream <- Stream.resource(Resource.make(IO(new FileInputStream(new File(path))))(x => IO(x.close())))

--- a/src/test/scala/ai/metarank/util/CSVStreamTest.scala
+++ b/src/test/scala/ai/metarank/util/CSVStreamTest.scala
@@ -13,4 +13,14 @@ class CSVStreamTest extends AnyFlatSpec with Matchers {
     result.map(_.toList) shouldBe List(List("1", "2", "3"), List("4", "5", "6"))
     file.delete()
   }
+
+  it should "handle RFC4180 double quotes" in {
+    val file = File.newTemporaryFile("csv", ".csv")
+    file.writeText(
+      """foo,2,3
+        |bar"",5,6""".stripMargin)
+    val result = CSVStream.fromFile(file.toString(), ',', 0).compile.toList.unsafeRunSync()
+    result.map(_.toList) shouldBe List(List("foo", "2", "3"), List("bar\"", "5", "6"))
+    file.delete()
+  }
 }


### PR DESCRIPTION
So it will parse CSVs with embeddings of this format:
```
socks,2,3,4,5,6,7
""red"" socks,2,3,4,5,6,7
```