### PR TITLE
unbreak e2e tests for kafka

### DIFF
--- a/.github/compose-connectors.yaml
+++ b/.github/compose-connectors.yaml
@@ -57,6 +57,7 @@ services:
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
       - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
       - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_NODE_ID=1
 
   pulsar:
     image: apachepulsar/pulsar:2.11.0


### PR DESCRIPTION
Bitnami's kafka requires `KAFKA_CFG_NODE_ID` to be set for KRaft from 3.3.x