### PR TITLE
fix crash on scalar codec with long numeric lists

### DIFF
--- a/src/main/scala/ai/metarank/fstore/codec/impl/ScalarCodec.scala
+++ b/src/main/scala/ai/metarank/fstore/codec/impl/ScalarCodec.scala
@@ -20,11 +20,11 @@ object ScalarCodec extends BinaryCodec[Scalar] {
       out.writeBoolean(value)
     case Scalar.SStringList(value) =>
       out.writeByte(3)
-      out.writeByte(value.length)
+      out.writeVarInt(value.length)
       value.foreach(out.writeUTF)
     case Scalar.SDoubleList(value) =>
       out.writeByte(4)
-      out.writeByte(value.length)
+      out.writeVarInt(value.length)
       value.foreach(out.writeDouble)
   }
 

--- a/src/test/scala/ai/metarank/fstore/redis/codec/impl/ScalarCodecTest.scala
+++ b/src/test/scala/ai/metarank/fstore/redis/codec/impl/ScalarCodecTest.scala
@@ -18,6 +18,9 @@ class ScalarCodecTest extends AnyFlatSpec with Matchers with BinCodecTest {
   it should "do string lists" in {
     roundtrip(ScalarCodec, SStringList(List("foo", "bar")))
   }
+  it should "do string lists size=1000" in {
+    roundtrip(ScalarCodec, SStringList((0 until 1000).map(_.toString).toList))
+  }
   it should "do double lists" in {
     roundtrip(ScalarCodec, SDoubleList(Array(1.0, 2.3)))
   }


### PR DESCRIPTION
We write byte length, and read a varint. When length > 128, then BOOM.