### PR TITLE
fix crash on reopening existing file state db

### DIFF
--- a/src/main/scala/ai/metarank/fstore/file/client/MapDBClient.scala
+++ b/src/main/scala/ai/metarank/fstore/file/client/MapDBClient.scala
@@ -8,12 +8,12 @@ import java.nio.file.{Files, Path, Paths}
 
 class MapDBClient(db: DB) extends FileClient {
   override def hashDB(name: String): HashDB = {
-    val hash = db.hashMap(name, Serializer.STRING, Serializer.BYTE_ARRAY).create()
+    val hash = db.hashMap(name, Serializer.STRING, Serializer.BYTE_ARRAY).createOrOpen()
     MapdbHashDB(hash)
   }
 
   override def sortedStringDB(name: String): SortedDB[String] = {
-    val tree = db.treeMap(name, Serializer.STRING, Serializer.STRING).maxNodeSize(16).create()
+    val tree = db.treeMap(name, Serializer.STRING, Serializer.STRING).maxNodeSize(16).createOrOpen()
     MapdbSortedDB(tree, _.length)
   }
 
@@ -22,7 +22,7 @@ class MapDBClient(db: DB) extends FileClient {
       .treeMap(name, Serializer.STRING, Serializer.BYTE_ARRAY)
       .maxNodeSize(16)
       .valuesOutsideNodesEnable()
-      .create()
+      .createOrOpen()
     MapdbSortedDB(tree, _.length)
   }
 
@@ -31,13 +31,13 @@ class MapDBClient(db: DB) extends FileClient {
       .treeMap(name, Serializer.STRING, ScalaFloatSerializer)
       .maxNodeSize(16)
       .valuesOutsideNodesEnable()
-      .create()
+      .createOrOpen()
     MapdbSortedDB(tree, _ => 4)
   }
 
   override def sortedIntDB(name: String): SortedDB[Int] = {
     val tree =
-      db.treeMap(name, Serializer.STRING, ScalaIntSerializer).maxNodeSize(16).create()
+      db.treeMap(name, Serializer.STRING, ScalaIntSerializer).maxNodeSize(16).createOrOpen()
     MapdbSortedDB(tree, _ => 4)
   }
 

--- a/src/test/scala/ai/metarank/fstore/file/client/MapDBClientTest.scala
+++ b/src/test/scala/ai/metarank/fstore/file/client/MapDBClientTest.scala
@@ -8,4 +8,16 @@ class MapDBClientTest extends FileTestSuite {
   override def makeHash(): HashDB = mapdb.hashDB("yep" + Random.nextInt())
 
   override def makeTree(): SortedDB[String] = mapdb.sortedStringDB("baa" + Random.nextInt())
+
+  it should "reopen the same state file" in {
+    val path = Files.createTempDirectory("tmp")
+    val db1  = MapDBClient.createUnsafe(path)
+    val kv1  = db1.hashDB("test")
+    kv1.put("foo", "bar".getBytes())
+    db1.close()
+
+    val db2 = MapDBClient.createUnsafe(path)
+    val kv2 = db2.hashDB("test")
+    kv2.get("foo").map(b => new String(b)) shouldBe Some("bar")
+  }
 }


### PR DESCRIPTION
For the ESCI demo, where we're going to use the file state instead of redis - as it's easier to wrap in into docker