### PR TITLE
expose all bi/cross encoder features in the /inference endpoint by default

### DIFF
--- a/src/main/scala/ai/metarank/api/routes/inference/CrossEncoderApi.scala
+++ b/src/main/scala/ai/metarank/api/routes/inference/CrossEncoderApi.scala
@@ -4,6 +4,7 @@ import ai.metarank.ml.onnx.sbert.{OnnxCrossEncoder, OnnxSession}
 import ai.metarank.api.JsonChunk
 import ai.metarank.api.routes.inference.BiEncoderApi.{BiencoderRequest, BiencoderResponse}
 import ai.metarank.api.routes.inference.CrossEncoderApi.{CrossEncoderRequest, CrossEncoderResponse}
+import ai.metarank.feature.FieldMatchCrossEncoderFeature
 import ai.metarank.ml.onnx.encoder.EncoderConfig
 import ai.metarank.ml.onnx.encoder.EncoderConfig.CrossEncoderConfig
 import ai.metarank.ml.onnx.sbert.OnnxCrossEncoder.SentencePair
@@ -51,16 +52,28 @@ object CrossEncoderApi extends Logging {
   implicit val crossRequestJson: EntityDecoder[IO, CrossEncoderRequest]   = jsonOf[IO, CrossEncoderRequest]
   implicit val crossResponseJson: EntityEncoder[IO, CrossEncoderResponse] = jsonEncoderOf[CrossEncoderResponse]
 
-  def create(models: Map[String, EncoderConfig]): IO[CrossEncoderApi] = for {
-    bi <- IO(models.collect { case (name, c: CrossEncoderConfig) =>
-      name -> c
-    })
-    encoders <- bi.toList.traverseCollect { case (name, CrossEncoderConfig(Some(handle), _, mf, vc)) =>
-      OnnxSession.load(handle, mf, vc).map(session => name -> OnnxCrossEncoder(session))
+  def create(models: Map[String, EncoderConfig], existing: List[FieldMatchCrossEncoderFeature]): IO[CrossEncoderApi] =
+    for {
+      bi <- IO(models.collect { case (name, c: CrossEncoderConfig) =>
+        name -> c
+      })
+      encoders <- bi.toList.traverseCollect { case (name, CrossEncoderConfig(Some(handle), _, mf, vc)) =>
+        existing.find(_.schema.method.model.contains(handle)) match {
+          case None => OnnxSession.load(handle, mf, vc).map(session => name -> OnnxCrossEncoder(session))
+          case Some(cross) =>
+            cross.encoder match {
+              case Some(encoder) =>
+                info(s"re-using ${cross.schema.method.model} ONNX session for /inference/cross/$name") *> IO.pure(
+                  name -> encoder
+                )
+              case None => OnnxSession.load(handle, mf, vc).map(session => name -> OnnxCrossEncoder(session))
+            }
+        }
+
+      }
+      _ <- IO.whenA(encoders.nonEmpty)(info(s"loaded ${encoders.map(_._1)} cross-encoders for inference"))
+    } yield {
+      CrossEncoderApi(encoders.toMap)
     }
-    _ <- IO.whenA(encoders.nonEmpty)(info(s"loaded ${encoders.map(_._1).toList} cross-encoders for inference"))
-  } yield {
-    CrossEncoderApi(encoders.toMap)
-  }
 
 }

--- a/src/main/scala/ai/metarank/config/Config.scala
+++ b/src/main/scala/ai/metarank/config/Config.scala
@@ -1,6 +1,9 @@
 package ai.metarank.config
 
 import ai.metarank.config.StateStoreConfig.{MemoryStateConfig, RedisStateConfig}
+import ai.metarank.feature.FieldMatchBiencoderFeature
+import ai.metarank.feature.FieldMatchBiencoderFeature.FieldMatchBiencoderSchema
+import ai.metarank.feature.FieldMatchCrossEncoderFeature.FieldMatchCrossEncoderSchema
 import ai.metarank.ml.onnx.encoder.EncoderConfig
 import ai.metarank.model.FeatureSchema
 import ai.metarank.util.Logging
@@ -38,6 +41,10 @@ object Config extends Logging {
         val state = get(stateOption, MemoryStateConfig(), "state")
         val train = get(trainOption, TrainConfig.fromState(state), "train")
         val core  = coreOption.getOrElse(CoreConfig())
+        val inferenceDefault = features.toList.flatten.collect {
+          case x: FieldMatchBiencoderSchema    => x.name.value -> x.method
+          case x: FieldMatchCrossEncoderSchema => x.name.value -> x.method
+        }.toMap
         Config(
           core,
           api,
@@ -46,7 +53,7 @@ object Config extends Logging {
           inputOption,
           features.getOrElse(Nil),
           models.getOrElse(Map.empty),
-          inference.getOrElse(Map.empty)
+          inference.getOrElse(inferenceDefault)
         )
       }
     )

--- a/src/main/scala/ai/metarank/ml/onnx/ModelHandle.scala
+++ b/src/main/scala/ai/metarank/ml/onnx/ModelHandle.scala
@@ -15,8 +15,11 @@ object ModelHandle {
 
   case class HuggingFaceHandle(ns: String, name: String) extends ModelHandle {
     override def asList: List[String] = List(ns, name)
+
+    override def toString: String = s"hf://$ns/$name"
   }
   case class LocalModelHandle(dir: String) extends ModelHandle {
+    override def toString: String     = s"file://$dir"
     override def name: String         = dir
     override def asList: List[String] = List(dir)
   }

--- a/src/test/scala/ai/metarank/config/ConfigInferenceTest.scala
+++ b/src/test/scala/ai/metarank/config/ConfigInferenceTest.scala
@@ -28,4 +28,36 @@ class ConfigInferenceTest extends AnyFlatSpec with Matchers {
       )
     )
   }
+
+  it should "pick existing encoders as default inference endpoints" in {
+    val yaml =
+      """
+        |models:
+        |  default:
+        |    type: lambdamart
+        |    weights: {}
+        |    backend:
+        |      type: xgboost
+        |    features:
+        |    - foo
+        |features:
+        |  - type: field_match
+        |    name: foo
+        |    rankingField: ranking.query
+        |    itemField: item.title
+        |    distance: cosine
+        |    method:
+        |      type: bi-encoder
+        |      dim: 384
+        |      model: metarank/all-MiniLM-L6-v2""".stripMargin
+    val parsed = parse(yaml).flatMap(_.as[Config])
+    parsed.map(_.inference) shouldBe Right(
+      Map(
+        "foo" -> BiEncoderConfig(
+          model = Some(HuggingFaceHandle("metarank", "all-MiniLM-L6-v2")),
+          dim = 384
+        )
+      )
+    )
+  }
 }

--- a/src/test/scala/ai/metarank/main/api/BiEncoderApiTest.scala
+++ b/src/test/scala/ai/metarank/main/api/BiEncoderApiTest.scala
@@ -21,7 +21,8 @@ class BiEncoderApiTest extends AnyFlatSpec with Matchers {
           model = Some(HuggingFaceHandle("metarank", "all-MiniLM-L6-v2")),
           dim = 384
         )
-      )
+      ),
+      existing = Nil
     )
     .unsafeRunSync()
 


### PR DESCRIPTION
So you don't need to re-define them again in the `inference` config section. This will also reuse the onnx session.