### PR TITLE
set default api timeout to 5 minutes

### DIFF
--- a/src/main/scala/ai/metarank/config/ApiConfig.scala
+++ b/src/main/scala/ai/metarank/config/ApiConfig.scala
@@ -3,10 +3,12 @@ package ai.metarank.config
 import ai.metarank.util.Logging
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
+import scala.concurrent.duration._
 
-case class ApiConfig(host: Hostname = Hostname("0.0.0.0"), port: Port = Port(8080))
+case class ApiConfig(host: Hostname = Hostname("0.0.0.0"), port: Port = Port(8080), timeout: FiniteDuration = 5.minutes)
 
 object ApiConfig extends Logging {
+  import ai.metarank.util.DurationJson._
   implicit val apiConfigDecoder: Decoder[ApiConfig] = Decoder.instance(c =>
     for {
       host <- c.downField("host").as[Option[Hostname]].map {
@@ -21,8 +23,14 @@ object ApiConfig extends Logging {
           logger.info("api.port is not set, using 8080 as default")
           Port(8080)
       }
+      timeout <- c.downField("timeout").as[Option[FiniteDuration]].map {
+        case Some(value) => value
+        case None =>
+          logger.info("api.timeout is not set, using 5 minutes as default")
+          5.minutes
+      }
     } yield {
-      ApiConfig(host, port)
+      ApiConfig(host, port, timeout)
     }
   )
 }

--- a/src/main/scala/ai/metarank/main/command/Serve.scala
+++ b/src/main/scala/ai/metarank/main/command/Serve.scala
@@ -22,6 +22,7 @@ import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.hotspot.DefaultExports
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
+import scala.concurrent.duration._
 
 object Serve extends Logging {
   def run(
@@ -86,6 +87,9 @@ object Serve extends Logging {
       .bindHttp(conf.port.value, conf.host.value)
       .withHttpApp(httpApp)
       .withBanner(Logo.lines)
+      .withIdleTimeout(conf.timeout)
+      // response header timeout should be less than idle timeout
+      .withResponseHeaderTimeout(conf.timeout - 1.second)
 
     _ <- info("Starting API...")
     _ <- api.serve.compile.drain


### PR DESCRIPTION
A fix for a timeout issue on doing `/train` API call. A code authored by `Yuri` from slack.