### PR TITLE
fix: Metarank gets killed (oomkiller): not closed outputstream in binary format with compress enabled

### DIFF
--- a/src/main/scala/ai/metarank/fstore/codec/values/BinaryVCodec.scala
+++ b/src/main/scala/ai/metarank/fstore/codec/values/BinaryVCodec.scala
@@ -41,6 +41,7 @@ case class BinaryVCodec[T](compress: Boolean, codec: BinaryCodec[T]) extends VCo
     }
     codec.write(value, stream)
     stream.flush()
+    stream.close()
     bytes.toByteArray
   }
 


### PR DESCRIPTION
Hi,

This PR fixes a memory leak/heavy consumption of memory using the binary format with compression enabled.

### Details
We found a potential memory leak, when calling the /feedback API, with lots of data.
Symptom: Metarank eats the memory (defined with `-Xmx`) and is killed by the OOMKiller after some time.

Using the profiler, we found that the binary format with compression was consuming a lots of memory, and that the stream was actually not closed.

### Reproduce

- We are sending ~200k events to /feedback in bulk on 10 events
- `-Xmx8g` (or more)
- Metarank is killed after ingesting ~3k events

### Workaround
Metarank is not killed and works perfectly fine with less memory! (`-Xmx1g`).
This is strange and funny! But why not :)

### Version
- version 0.7.2 (jar)
- JDK 11
- Redis

Config:
```yaml
state:
  type: redis
  host: localhost
  port: 6379
  tls:
    enabled: false
    verify: "off"
  timeout:
    connect: 60s
    socket: 60s
    command: 60s
source:
  type: file
api:
  port: 8081
models:
  global-clicks-lightgbm:
    type: lambdamart
    backend:
      type: lightgbm
      seed: 42
      iterations: 200
    weights:
      click: 1
    features:
      - global_item_click_count
features:
  - name: global_item_click_count
    type: interaction_count
    interaction: click
    scope: item
```
