### PR TITLE
clamp xgboost weights to 31

### DIFF
--- a/src/test/scala/ai/metarank/config/ModelConfigTest.scala
+++ b/src/test/scala/ai/metarank/config/ModelConfigTest.scala
@@ -46,4 +46,25 @@ class ModelConfigTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "clip xgboost weights for lmart" in {
+    val yaml =
+      """
+        |type: lambdamart
+        |weights:
+        |  click: 1
+        |  purchase: 100
+        |backend:
+        |  type: xgboost
+        |features: [foo]""".stripMargin
+
+    val decoded = io.circe.yaml.parser.parse(yaml).flatMap(_.as[ModelConfig])
+    decoded shouldBe Right(
+      LambdaMARTConfig(
+        backend = XGBoostConfig(),
+        features = NonEmptyList.one(FeatureName("foo")),
+        weights = Map("click" -> 1.0, "purchase" -> 31.0)
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
A fix for issue like this:
```
08:11:56.589 INFO  a.m.m.r.LambdaMARTRanker$LambdaMARTPredictor - Train/Test split finished: 800295/200074 click-through events
2024-01-17T08:12:01.911Z [WARNING] Your app's responsiveness to a new asynchronous event (such as a new connection, an upstream response, or a timer) was in excess of 100 milliseconds. Your CPU is probably starving. Consider increasing the granularity of your delays or adding more cedes. This may also be a sign that you are unintentionally running blocking I/O operations (such as File or InetAddress) without the blocking combinator.
ml.dmlc.xgboost4j.java.XGBoostError: [08:13:12] /workspace/src/common/ranking_utils.h:355: Check failed: label_is_valid: Relevance degress must be lesser than or equal to 31 when the exponential NDCG gain function is used. Set `ndcg_exp_gain` to false to use custom DCG gain.
Stack trace:
  [bt] (0) /tmp/libxgboost4j12195132296382762716.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x6e) [0x7f626e57ec4e]
  [bt] (1) /tmp/libxgboost4j12195132296382762716.so(xgboost::ltr::NDCGCache::InitOnCPU(xgboost::Context const*, xgboost::MetaInfo const&)+0xcf6) [0x7f626e68f996]
  [bt] (2) /tmp/libxgboost4j12195132296382762716.so(std::shared_ptr<xgboost::ltr::NDCGCache> xgboost::DMatrixCache<xgboost::ltr::NDCGCache>::CacheItem<xgboost::Context const*, xgboost::MetaInfo, xgboost::ltr::LambdaRankParam>(std::shared_ptr<xgboost::DMatrix>, xgboost::Context const* const&, xgboost::MetaInfo const&, xgboost::ltr::LambdaRankParam const&)+0x46b) [0x7f626e96f0bb]
```

In a case when xgboost is used, and there is a weight > 31, then we emit a warning and clamp it to 31.