### PR TITLE
GCP Memstore redis: add extra toggle to disable CLIENT TRACKING cache invalidation

### DIFF
--- a/.github/compose-redis.yaml
+++ b/.github/compose-redis.yaml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   redis:
-    image: 'redis:7.0.5'
+    image: 'redis:7.2.4'
     ports:
       - '6379:6379'
+    command: ['--user', 'default', 'on','nopass','~*','&*','+@all','-client']

--- a/doc/configuration/persistence.md
+++ b/doc/configuration/persistence.md
@@ -36,6 +36,7 @@ state:
   cache:           # optional
     maxSize: 1024  # size of in-memory client-side cache for hot keys, optional, default=1024
     ttl: 1h        # how long should key-values should be cached, optional, default=1h
+    clientTracking: true # should we subscribe for CLIENT TRACKING invalidation events
 
   pipeline:         # optional
     maxSize: 128    # batch write buffer size, optional, default=128
@@ -207,4 +208,6 @@ important factor.
 
 * Metarank requires Redis 6+ due to a lack of client-side caching support in 5.x
   * you can disable client caching altogether (for example, for managed Redis-compatible engines, like GCP Memorystore Redis) with `cache.maxSize: 0`.
+  * For GCP Memorystore Redis, you can also set `state.cache.clientTracking: false` to disable the `CLIENT TRACKING` cache 
+  eviction support: GCP Memstore has client-side caching disabled even on 7.x Redis cluster.
 * Redis Cluster is not yet supported; see ticket [568](https://github.com/metarank/metarank/issues/568) for the progress.

--- a/src/main/scala/ai/metarank/config/StateStoreConfig.scala
+++ b/src/main/scala/ai/metarank/config/StateStoreConfig.scala
@@ -49,16 +49,18 @@ object StateStoreConfig extends Logging {
       }
     )
 
-    case class CacheConfig(maxSize: Int = 4096, ttl: FiniteDuration = 1.hour)
+    case class CacheConfig(maxSize: Int = 4096, ttl: FiniteDuration = 1.hour, clientTracking: Boolean = true)
 
     implicit val cacheConfigDecoder: Decoder[CacheConfig] = Decoder.instance(c =>
       for {
-        maxSize <- c.downField("maxSize").as[Option[Int]]
-        ttl     <- c.downField("ttl").as[Option[FiniteDuration]]
+        maxSize    <- c.downField("maxSize").as[Option[Int]]
+        ttl        <- c.downField("ttl").as[Option[FiniteDuration]]
+        invalidate <- c.downField("clientTracking").as[Option[Boolean]]
       } yield {
         CacheConfig(
           maxSize = maxSize.getOrElse(CacheConfig().maxSize),
-          ttl = ttl.getOrElse(CacheConfig().ttl)
+          ttl = ttl.getOrElse(CacheConfig().ttl),
+          clientTracking = invalidate.getOrElse(true)
         )
       }
     )


### PR DESCRIPTION
So now it prints a proper warning with an advice on what to do if got NOPERM for CLIENT TRACKING command.

Fixes https://github.com/metarank/metarank/issues/1225