### PR TITLE
doc: Fix typos, spelling inconsistencies, and sentence semantic mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ curl http://localhost:8080/feedback \
 }'
 ```
 
-> Now, let's intereact with the items `93363`
+> Now, let's interact with the items `93363`
 
 ```bash
 # click on the item with id 93363

--- a/doc/api.md
+++ b/doc/api.md
@@ -159,7 +159,7 @@ define which model to invoke.
 - `items`: which particular items were displayed to the visitor.
 - `items.id`: id of the content item. Should match the `item` property from item metadata event.
 - `items.fields`: an optional set of per-item fields, for example BM25 scores coming from ES. See [how to use BM25 scores](configuration/features/relevancy.md#ranking) in ranking.
-- `items.label`: an optional field for explicit relevance judgments.
+- `items.label`: an optional field for explicit relevance judgements.
 
 ### Response format
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -177,7 +177,7 @@ define which model to invoke.
 - `took`: number of millis spend processing request
 - `items.id`: id of the content item. Will match `item` property from the item metadata event.
 - `items.score`: a score calculated by personalization model
-- `items.features`: an array of feature values calculated by pesonaliization model. This field will be returned if `explain` field is set to `true` in the request. The structure of this object will vary depending on the feature type.
+- `items.features`: an array of feature values calculated by personalization model. This field will be returned if `explain` field is set to `true` in the request. The structure of this object will vary depending on the feature type.
 
 ## Recommendations
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -53,7 +53,7 @@ Check our [blog](https://blog.metarank.ai) for more detailed updates.
 * `field_match` support for [BM25](configuration/features/text.md#bm25-score)
 * `field_match` support for [LLM bi-encoders](configuration/features/text.md#llm-bi-encoders)
 * `field_match` support for [LLM cross-encoders](configuration/features/text.md#llm-cross-encoders)
-* Relevance judgments can now also [be explicit](event-schema.md#ranking-event)
+* Relevance judgements can now also [be explicit](event-schema.md#ranking-event)
 
 
 ## 0.6.4
@@ -125,7 +125,7 @@ Upgrading: note that redis state format has a non backwards compatible change, s
 
 * [`interacted_with`](configuration/features/user-session.md#interacted-with) feature now has much less overhead in Redis, and supports multiple fields in a single visitor profile.
 * [click-through events now can be stored in a file](configuration/overview.md#training), and not inside Redis, also reducing the overall costs of running Metarank
-* it is now possible to [export lightgbm/xgboost-compatible](cli.md#dataset-export) datasets for further hyper-parameter optimization.
+* it is now possible to [export lightgbm/xgboost-compatible](cli.md#dataset-export) datasets for further hyperparameter optimization.
 
 ## 0.5.8
 
@@ -145,13 +145,13 @@ Upgrading: note that redis state format has a non backwards compatible change, s
 * [Binary state serialization format](configuration/persistence.md#state-encoding-formats), which is 2x faster and 4x more compact than JSON
 * [Multi-arch docker images](deploy/docker.md), so metarank can now be run natively on Mac M1/M2.
 * [Kubernetes Helm chart](deploy/kubernetes.md) and an official guide on how to do production deployment on k8s.
-* [Training dataset export](cli.md#training-the-model) for further hyper-parameter tuning.
+* [Training dataset export](cli.md#training-the-model) for further hyperparameter tuning.
 
 ## 0.5.5
 Notable features:
 * [Rate normalization](configuration/features/counters.md#rate-normalization) support, so having 1 click over 2 
 impressions is not resulting in a 50% CTR anymore.
-* [Position de-biasing](configuration/features/relevancy.md#position) based on a dynamic position feature.
+* [Position debiasing](configuration/features/relevancy.md#position) based on a dynamic position feature.
 
 ## 0.5.4
 Most notable improvements:

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -169,7 +169,7 @@ Highlights of this release are:
 ## 0.5.1
 
 Highlights of this release are:
-* Flink is rermoved. As a result only `memory` and `redis` [persistance](configuration/persistence.md) modes are supported now.
+* Flink is removed. As a result only `memory` and `redis` [persistence](configuration/persistence.md) modes are supported now.
 * [Configuration file](configuration/sample-config.yml) now has updated structure and is not compatible with previous format.
 * CLI is updated, most of the options are moved to [configuration](configuration/overview.md).
   * We have updated the [`validate`](cli.md#validation) mode of the CLI, so you can use it to validate your data and configuration.
@@ -181,14 +181,14 @@ Highlights of this release are:
 * Kinesis source: on par with Kafka and Pulsar
 * Custom connector options pass-through
 
-### Kunernetes support
+### Kubernetes support
 
 Metarank is a multi-stage and multi-component system, and now it's possible to get it deployed
 in minutes inside a Kubernetes cluster:
 * Inference API is just a regular [Deployment](https://github.com/metarank/metarank/blob/master/deploy/kubernetes/deployment.yaml)
 * Bootstrap, Upload and Update jobs can be run both locally (to simplify things up for small datasets) and
 inside the cluster in a distributed mode.
-* Job mabagement is done with [flink-kubernetes-operator](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/)
+* Job management is done with [flink-kubernetes-operator](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/)
 
 See [this doc section](https://docs.metarank.ai/deployment/kubernetes) for details.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -134,7 +134,7 @@ Metarank CLI has a set of different running modes:
 * [`validate`](#validation): validates data nd configuration files.
 * [`sort`](#historical-data-sorting): pre-sorts the dataset by timestamp.
 * [`autofeature`](#auto-feature-generation): automatically generates feature configuration based on your data.
-* [`export`](#dataset-export): export the training dataset for further hyperparam optimization.
+* [`export`](#dataset-export): export the training dataset for further hyperparameter optimization.
 * [`termfreq`](): compute term frequency dictionary for [BM25 field_match extractor](configuration/features/text.md#text-based-extractors)
 
 ### Validation
@@ -226,7 +226,7 @@ The format of split strategy CLI flag is `--strategy name=ratio%`. For example:
 
 ### Dataset export
 
-Metarank can emit CSV/LibSVM formatted datasets and corresponding config files for LightGBM and XGBoost, so you can later perform a hyper-parameter optimization using your favourite tool:
+Metarank can emit CSV/LibSVM formatted datasets and corresponding config files for LightGBM and XGBoost, so you can later perform a hyperparameter optimization using your favourite tool:
 
 ```shell
 java -jar metarank.jar export --config /path/to/config.yaml --model <modelname> --out /export/dir

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -81,7 +81,7 @@ Subcommand: sort - sort the dataset by timestamp
 
 Subcommand: autofeature - generate reference config based on existing data
   -c, --cat-threshold  <arg>   min threshold of category frequency, when its
-                               considered a catergory (optional, default=0.003)
+                               considered a category (optional, default=0.003)
   -d, --data  <arg>            path to an input file
   -f, --format  <arg>          input file format: json, snowplow, snowplow:tsv,
                                snowplow:json (optional, default=json)
@@ -345,7 +345,7 @@ To use the BM25 score in the [field_match](configuration/features/text.md#fieldm
 To do so, run the `termfreq` subcommand:
 ```shell
 
-$> java -jar meratank.jar termfreq --data <path-to-data>\
+$> java -jar metarank.jar termfreq --data <path-to-data>\
      --out /term-freq.json --fields title,description --language en
      
 

--- a/doc/configuration/features/relevancy.md
+++ b/doc/configuration/features/relevancy.md
@@ -1,11 +1,11 @@
-# Relevvancy feature extractors
+# Relevancy feature extractors
 
 ## Ranking
 
 While implementing Learn-to-Rank systems, Metarank is designed to be a satellite secondary reranking system. It 
 assumes that there exists another service which generates candidates for the reranking process:
 * in search: Elasticsearch or SOLR
-* in recommendations: output of spark mmlib ALS recommender
+* in recommendations: output of spark mllib ALS recommender
 * in ecommerce: inventory database
 
 Most of these primary sources of input may also have a per-item score: how much this item is matching the original query:
@@ -47,7 +47,7 @@ Metarank <= 0.5.11 included now deprecated `relevancy` extractor. With Metarank 
 
 As there can be multiple per-item fields in the ranking event, it means that it's also possible to have multiple first-level relevancy signals. For example, when you have a hybrid search application with two retrievals:
 * Elasticsearch/OS/Solr for regular term search, giving you a per-document BM25 score.
-* PineCone/Vespa/QDrant/etc. vector search engine, doing a k-NN lookup over neural-based query embedding, giving you cosine similarity score.
+* PineCone/Vespa/Qdrant/etc. vector search engine, doing a k-NN lookup over neural-based query embedding, giving you cosine similarity score.
 
 The app retrieves top-N documents from both sources, and then merges them together in a single list. Some documents may come from both retrievers, and some - only from one.
 

--- a/doc/configuration/features/relevancy.md
+++ b/doc/configuration/features/relevancy.md
@@ -6,7 +6,7 @@ While implementing Learn-to-Rank systems, Metarank is designed to be a satellite
 assumes that there exists another service which generates candidates for the reranking process:
 * in search: Elasticsearch or SOLR
 * in recommendations: output of spark mllib ALS recommender
-* in ecommerce: inventory database
+* in e-commerce: inventory database
 
 Most of these primary sources of input may also have a per-item score: how much this item is matching the original query:
 * BM25 or TF/IDF score in search

--- a/doc/configuration/features/scalar.md
+++ b/doc/configuration/features/scalar.md
@@ -137,7 +137,7 @@ Supported reducers are:
 * `vectorN` - take first N items from the sequence, and pad remaining with zeroes. So `vector10` means a vector of 10 dimensions.
 
 The `vectorN` reducer can also be useful if you compute embeddings (fields with constant predefined size) for your user/items as you can wrap them as ranking features directly. 
-For example, when your item has a field `als_embedding: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`, you can define a `vector` feature with `reduce: vector10` and the raw embedding will be short-cirquited as a set of 10 separate numerical features for the ranking model.
+For example, when your item has a field `als_embedding: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`, you can define a `vector` feature with `reduce: vector10` and the raw embedding will be short-circuited as a set of 10 separate numerical features for the ranking model.
 
 ## String extractors
 

--- a/doc/configuration/features/user-session.md
+++ b/doc/configuration/features/user-session.md
@@ -20,7 +20,7 @@ Mozilla/5.0 (iPhone; CPU iPhone OS 15_3_1 like Mac OS X) AppleWebKit/605.1.15 (K
 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36 Edg/98.0.1108.62
 ```
 
-There is a large collaborative effort to build a database of typical UA patterns, (UA-Parser)[https://github.com/ua-parser],
+There is a large collaborative effort to build a database of typical UA patterns, [UA-Parser](https://github.com/ua-parser),
 which is used to extract all the possible item metadata from these strings. 
 
 To map this to actual ML features, there is a predefined set of mappers:

--- a/doc/configuration/features/user-session.md
+++ b/doc/configuration/features/user-session.md
@@ -118,5 +118,5 @@ A source field can be of a user/ranking/interaction type, and feature extractor 
 * there can be multiple referers. For example, visitor lands on a site from google (and gets a "search" referer),
   then does a couple of interactions with the site (and also gets an "internal" referer medium)
 
-In a case when a visitor has multiple referers memorized, then the one-hot-encoded vector will have multiple flags enabled,
+In a case when a visitor has multiple referers memorised, then the one-hot-encoded vector will have multiple flags enabled,
 like `[0, 1, 1, 0, 0, 0]` for a case with search+internal referer mediums.

--- a/doc/configuration/inference-models.md
+++ b/doc/configuration/inference-models.md
@@ -3,8 +3,8 @@
 Inference models allow to re-rank search results using pre-train LLMs (Large Language Models). You can use Metarank's pre-built models or provide your own. 
 At the moment `cross-encoder` and `bi-encoder` model types are supported.
 
-Metarank uses [ONNX](https://onnx.ai/) for loading models and can handle referecing models from [HugginFace](https://huggingface.co/metarank) or local files. 
-In the `model` section of the configuration you can specify either a HugginFace handle, e.g. `metarank/ce-msmarco-MiniLM-L6-v2metarank/ce-msmarco-MiniLM-L6-v2` or a local file `file://local-folder/model.onnx`
+Metarank uses [ONNX](https://onnx.ai/) for loading models and can handle referencing models from [HuggingFace](https://huggingface.co/metarank) or local files. 
+In the `model` section of the configuration you can specify either a HuggingFace handle, e.g. `metarank/ce-msmarco-MiniLM-L6-v2metarank/ce-msmarco-MiniLM-L6-v2` or a local file `file://local-folder/model.onnx`
 
 ```yaml
 inference:
@@ -16,7 +16,7 @@ inference:
 ## Cross-encoders
 
 Cross-encoder LLMs are using the semantic power of LLMs to provider a better order for your results. Typically, cross-encoder LLM is much more precise than bi-encoder.
-With `vocabFile` option you can specify a file containing text vocabulry. 
+With `vocabFile` option you can specify a file containing text vocabulary. 
 With `cache` option you can specify a csv file containing `query`, `item` and `score` columns. Providing such a file can significantly speed up the training process.
 
 ```yaml
@@ -30,7 +30,7 @@ inference:
 
 ## Bi-encoders
 
-With `vocabFile` option you can specify a file containing text vocabulry.
+With `vocabFile` option you can specify a file containing text vocabulary.
 `itemFieldCache` and `rankingFieldCache` files can be used to significantly speed up the training process bby providing item and ranking embeddings upfront.
 The `itemFieldCache` file structure is as follows:
 ```csv

--- a/doc/configuration/inference-models.md
+++ b/doc/configuration/inference-models.md
@@ -1,6 +1,6 @@
 # Inference models
 
-Inference models allow to re-rank search results using pre-train LLMs (Large Language Models). You can use Metarank's pre-built models or provide your own. 
+Inference models allow to rerank search results using pre-train LLMs (Large Language Models). You can use Metarank's pre-built models or provide your own. 
 At the moment `cross-encoder` and `bi-encoder` model types are supported.
 
 Metarank uses [ONNX](https://onnx.ai/) for loading models and can handle referencing models from [HuggingFace](https://huggingface.co/metarank) or local files. 

--- a/doc/configuration/overview.md
+++ b/doc/configuration/overview.md
@@ -174,7 +174,7 @@ models:
     - popularity
     - genre
   # You can specify several models at once.
-  # This can be useful for A\B test scenarios or while testing different sets of features.
+  # This can be useful for A/B test scenarios or while testing different sets of features.
 
   #random:
   #  type: shuffle # shuffle model type produces random results
@@ -203,7 +203,7 @@ models:
 
 ## Inference
 
-The "inference" section describes inference model configuration for search results re-ranking. Check the [inference models](inference-models.md) section for more information.
+The "inference" section describes inference model configuration for search results reranking. Check the [inference models](inference-models.md) section for more information.
 
 ```yaml
 inference:

--- a/doc/configuration/recommendations/semantic.md
+++ b/doc/configuration/recommendations/semantic.md
@@ -33,7 +33,7 @@ Metarank has quite limited support for embeddings:
 
 A dictionary should be a comma-separated CSV-formatted file, where:
 * 1st column is product id
-* 2 till N+1 columns - float values for N-dimentional embedding
+* 2 till N+1 columns - float values for N-dimensional embedding
 
 Example:
 ```

--- a/doc/configuration/recommendations/similar.md
+++ b/doc/configuration/recommendations/similar.md
@@ -37,8 +37,8 @@ So Metarank does the following:
 * pre-builds a [HNSW](https://www.pinecone.io/learn/hnsw/) index for fast lookups for similar embeddings.
 * during inference (when you call the [/recommend/modelname](../../api.md#recommendations) endpoint), it makes a k-NN index lookup of similar items.
 
-Main pros and cons of such apporach:
+Main pros and cons of such approach:
 * *pros*: fast even for giant inventories, simple to implement
-* *cons*: lower precision compared to neural networks based methods like [BERT4rec](https://arxiv.org/abs/1904.06690), recommendations are not personalized.
+* *cons*: lower precision compared to neural networks based methods like [BERT4Rec](https://arxiv.org/abs/1904.06690), recommendations are not personalized.
 
 *There is an ongoing work in Metarank project to implement NN-based methods and make current ALS implementation personalized.*

--- a/doc/configuration/recommendations/similar.md
+++ b/doc/configuration/recommendations/similar.md
@@ -4,7 +4,7 @@
 
 Common use-cases for this model are:
 * you-may-also-like recommendations on item page: the context of the recommendation is a single item you're viewing now.
-* also-purchased widget on the cart page: the context of the recommendation is the contents of your card.
+* also-purchased widget on the cart page: the context of the recommendation is the contents of your cart.
 
 ## Configuration
 

--- a/doc/configuration/recommendations/trending.md
+++ b/doc/configuration/recommendations/trending.md
@@ -1,6 +1,6 @@
 # Trending items
 
-`trending` recommendation model is used to highlight the trending (or in other workds, most popular) items in your application. But it's not just about sorting items by popularity! 
+`trending` recommendation model is used to highlight the trending (or in other words, most popular) items in your application. But it's not just about sorting items by popularity! 
 
 Metarank can:
 * combine multiple types of interactions: you can mix clicks, likes and purchases with different weights.
@@ -32,7 +32,7 @@ models:
 The config above defines a trending model, accessible over the `/recommend/yolo-trending` [API endpoint](../../api.md):
 * the final item score combines click, like and purchase events
 * purchase has 3x more weight than click, like has 1.5x more weight than click
-* purchase has less agressive time decay
+* purchase has less aggressive time decay
 * only the last 30 days of data are used for clicks and purchases, but 60 days are used for likes
 
 ## Time decay and weight

--- a/doc/configuration/sample-config.yml
+++ b/doc/configuration/sample-config.yml
@@ -49,7 +49,7 @@ models:
       - popularity
       - genre
   # You can specify several models at once. 
-  # This can be useful for A\B test scenarios or while testing different sets of features.
+  # This can be useful for A/B test scenarios or while testing different sets of features.
 
   #random:
   #  type: shuffle # shuffle model type produces random results

--- a/doc/configuration/sample-config.yml
+++ b/doc/configuration/sample-config.yml
@@ -7,7 +7,7 @@
 
 # These features can be shared between multiple models, so if you have a model A using features 1-2-3 and
 # a model B using features 1-2, then all three features will be computed only once. 
-# You need to explicitely include a feature in the model configuration for Metarank to use it.
+# You need to explicitly include a feature in the model configuration for Metarank to use it.
 features:
   - name: popularity
     type: number
@@ -41,7 +41,7 @@ models:
     type: lambdamart # model type
     backend:
       type: xgboost # supported values: xgboost, lightgbm for lambdamart model
-      iterations: 100 # optional (default 100), number of interations while training the model
+      iterations: 100 # optional (default 100), number of interactions while training the model
       seed: 0 # optional (default = random), a seed to make training deterministic
     weights: # types and weights of interactions used in the model training
       click: 1 # you can increase the weight of some events to hint model to optimize more for them
@@ -49,7 +49,7 @@ models:
       - popularity
       - genre
   # You can specify several models at once. 
-  # This can be useful for A\B test scenarious or while testing different sets of features.
+  # This can be useful for A\B test scenarios or while testing different sets of features.
 
   #random:
   #  type: shuffle # shuffle model type produces random results

--- a/doc/configuration/supported-ranking-models.md
+++ b/doc/configuration/supported-ranking-models.md
@@ -11,11 +11,11 @@ models:
 ## LambdaMART
 
 LambdaMART is a Learn-to-Rank model, optimizing the [NDCG metric](https://en.wikipedia.org/wiki/Discounted_cumulative_gain). 
-There is a [Lambdamart in Depth](https://softwaredoug.com/blog/2022/01/17/lambdamart-in-depth.html)
+There is a [LambdaMART in Depth](https://softwaredoug.com/blog/2022/01/17/lambdamart-in-depth.html)
 article by [Doug Turnbull](https://softwaredoug.com) describing all the details about how it works. In a simplified way,
 LambdaMART in the scope of Metarank does the following:
 1. Takes a ranking and some relevancy judgements over items as an input (judgements can be implicit, like clicks, or 
-implicit like stars in movie recommendations)
+explicit like stars in movie recommendations)
 2. All items in the ranking have a set of characteristics (ML features, like genre or CTR as an example)
 3. A pair of items from the ranking is sampled.
 4. ML model must be able to guess which item in this pair may have higher relevancy judgement.

--- a/doc/configuration/supported-ranking-models.md
+++ b/doc/configuration/supported-ranking-models.md
@@ -34,7 +34,7 @@ To configure the model, use the following snippet:
     type: lambdamart 
     backend:
       type: xgboost # supported values: xgboost, lightgbm
-      iterations: 100 # optional (default 100), number of interations while training the model
+      iterations: 100 # optional (default 100), number of interactions while training the model
       seed: 0 # optional (default = random), a seed to make training deterministic
     weights: # types and weights of interactions used in the model training
       click: 1 # you can increase the weight of some events to hint model to optimize more for them

--- a/doc/deploy/custom-logging.md
+++ b/doc/deploy/custom-logging.md
@@ -41,7 +41,7 @@ ENV JAVA_OPTS="-Xmx1g -Dlogback.configurationFile=/app/logback.xml -Dlogback.deb
 
 ```
 
-Such a custom image will successfully load the custom conviguration with non-default appender:
+Such a custom image will successfully load the custom configuration with non-default appender:
 
 ```
 + OPTS='-Xmx1g -Dlogback.configurationFile=/app/logback.xml -Dlogback.debug=true'

--- a/doc/deploy/kubernetes.md
+++ b/doc/deploy/kubernetes.md
@@ -15,7 +15,7 @@ For a distributed K8S deployment, metarank requires the following external servi
 ## Data Import
 
 Metarank supports multiple ways of ingesting training data into the system:
-* event file can be HTTT POSTed to the `/feedback` endpoint using the [REST API](../api.md). Metarank does not do any in-memory buffering, so if your dataset is below 1GiB in size, this may be the simplest way to ingest.
+* event file can be HTTP POSTed to the `/feedback` endpoint using the [REST API](../api.md). Metarank does not do any in-memory buffering, so if your dataset is below 1GiB in size, this may be the simplest way to ingest.
 * event can be imported from a Kafka/Pulsar/Kinesis topic or read from files **locally**. Note that distributed import is not yet supported.
 
 We suggest to start with a HTTP-based event import, and switch to offline local import if you have any issues with it.

--- a/doc/deploy/standalone.md
+++ b/doc/deploy/standalone.md
@@ -8,7 +8,7 @@ setup instructions.
 
 Metarank has multiple running modes:
 * `import` - import historical clickthroughs to the store
-* `train` - run traing the machine learning model using the imported data
+* `train` - run training the machine learning model using the imported data
 * `serve` - start the ranking inference API
 * `standalone` - which is a shortcut for `import`, `train` and `serve` jobs run together.
 * `validate` - a set of sanity checks on your configuration file and event dataset.
@@ -44,7 +44,7 @@ Another option is to run Metarank standalone mode from a docker container:
 $ docker run -v /data/:<path to data dir> metarank/metarank:latest standalone --data /data/events.json --config /data/config.yml
 ```
 
-The follwing options are used for the docker container:
+The following options are used for the docker container:
 * `-v /data:<path to data dir>` to map a directory with input files and configuration into the container
 * `--data /data/events.json` to pass the name of [input events file](../event-schema.md), from the mapped volume
 * `--config /data/config.yml` to pass the [configuration file](../configuration/overview.md)
@@ -52,7 +52,7 @@ The follwing options are used for the docker container:
 During the startup process Metarank will:
 * import your dataset and compute all historical event statistics useful for machine learning model training
 * train the machine learning model you defined in the configuration file
-* start the inference API for real-time personaization.
+* start the inference API for real-time personalization.
 
 ![import and training process](../quickstart/img/training.gif)
 

--- a/doc/dev/production-recommendations.md
+++ b/doc/dev/production-recommendations.md
@@ -7,7 +7,7 @@ These are general recommendations on running Metarank in a production environmen
 ## Persistence
 
 Metarank provides several [Persistence](../configuration/persistence.md) options, however for production setup we recommend
-using only [Redis persistance](../configuration/persistence.md#redis-persistence) as it operates separately from running Metarank instances.
+using only [Redis persistence](../configuration/persistence.md#redis-persistence) as it operates separately from running Metarank instances.
 
 Redis does not depend on Metarank instances being re-deployed and should be configured with [disc backup](https://redis.io/docs/manual/persistence/).
 

--- a/doc/event-schema.md
+++ b/doc/event-schema.md
@@ -114,7 +114,7 @@ This information is used by personalization algorithms to understand which items
 - `items`: which particular items were displayed to the visitor.
 - `items.id`: id of the content item. Should match the `item` property from metadata event.
 - `items.fields`: a set of optional per-item fields.
-- `items.label`: an optional field for explicit relevance judgments.
+- `items.label`: an optional field for explicit relevance judgements.
 
 ## Interaction event
 

--- a/doc/guide/_index.md
+++ b/doc/guide/_index.md
@@ -6,7 +6,7 @@
   * Explicit and implicit feedback 
 * Generating configuration
 * Setting up ranking model (supported model types and options)
-  * Tuning model hyper-parameters 
+  * Tuning model hyperparameters 
 * Importing data
 * Deploying in Kubernetes
   * Model retraining 

--- a/doc/guide/search/cross-encoders.md
+++ b/doc/guide/search/cross-encoders.md
@@ -1,4 +1,4 @@
-# Search re-ranking with cross-encoder LLMs
+# Search reranking with cross-encoder LLMs
 
 In this guide we will set up Metarank as a simple inference server for cross-encoder LLMs (Large Language Models). In other words, we will use an open-source cross-encoder model to reorder your search results in a zero-shot manner, without collecting any visitor feedback data. We will use a pre-trained `MS-MARCO MiniLM-L6-v2` cross-encoder from the [sentence-transformers](https://sbert.net) package. 
 
@@ -20,7 +20,7 @@ For typical reranking scenarios, cross-encoders (even in zero-shot modes) are mu
 
 Let's imagine you already have a traditional search engine running (like Elasticsearch, OpenSearch or SOLR), which already has a good [recall](https://en.wikipedia.org/wiki/Precision_and_recall) level - it retrieves all the relevant products, but it sometimes struggles with precision: there can be some false-positives, and the ranking is not perfect.
 
-In this guide we will take top-N matching documents from your search engine, and re-rank them according to their semantic similarity with the query.
+In this guide we will take top-N matching documents from your search engine, and rerank them according to their semantic similarity with the query.
 
 ![reranking flow](../../img/reranking.png)
 

--- a/doc/guide/search/index.md
+++ b/doc/guide/search/index.md
@@ -6,11 +6,11 @@ There are two main approaches to search reranking:
 * **Zero-shot**: using generic approaches not fine-tuned on your dataset and visitor behavior. This does not require any telemetry collection and is a good starting point.
 * **Learn-to-Rank**: adapt ranking to the dataset and visitor behavior. Can yield better quality, with the drawback of requiring proper visitor analytics.
 
-## Zero-shot re-ranking
+## Zero-shot reranking
 
-If you're not familiar with concepts of re-ranking and Metarank, start with these intro guides to get better understanding about how things work:
+If you're not familiar with concepts of reranking and Metarank, start with these intro guides to get better understanding about how things work:
 
-* [Search re-ranking with cross-encoder LLMs](cross-encoders.md): How to use a general-purpose cross-encoder, pre-trained on MS-MARCO dataset to improve your Elasticsearch search relevance.
+* [Search reranking with cross-encoder LLMs](cross-encoders.md): How to use a general-purpose cross-encoder, pre-trained on MS-MARCO dataset to improve your Elasticsearch search relevance.
 * TODO: Semantic search with sentence-transformers and Qdrant: setting up Metarank as an inference server for bi-encoders for semantic retrieval with vector search.
 
 ## Learn-to-Rank

--- a/doc/howto/autofeature.md
+++ b/doc/howto/autofeature.md
@@ -32,7 +32,7 @@ Subcommand: autofeature - generate reference config based on existing data
   -r, --ruleset  <arg>   set of rules to generate config: stable, all (optional,
                          default=stable, values: [stable, all])
   -c, --cat-threshold  <arg>   min threshold of category frequency, when its
-                               considered a catergory (optional, default=0.003)
+                               considered a category (optional, default=0.003)
   -h, --help             Show help message
 
 For all other tricks, consult the docs on https://docs.metarank.ai
@@ -77,12 +77,12 @@ Process finished with exit code 0
 ## Supported heuristics
 
 Metarank has multiple sets of heuristics to generate feature configuration, toggled by the `--ruleset` CLI option:
-* stable: a default one, ruleset with less agressive heuristics, proven to be safe in production use.
+* stable: a default one, ruleset with less aggressive heuristics, proven to be safe in production use.
 * all: generates all features it can, even the problematic ones (like CTR, which may introduce biases).
 
 The following `stable` heuristics are supported:
 * **Numeric**: all numerical item fields are encoded as a [number](../configuration/features/scalar.md#numerical-extractor) feature.
-So for a numeric field `budget` describing a movie budget in dollars, it will generate the following feature extractor defitition:
+So for a numeric field `budget` describing a movie budget in dollars, it will generate the following feature extractor definition:
 ```yaml
 - source: item.budget
   type: number

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -136,7 +136,7 @@ curl http://localhost:8080/feedback \
 }'
 ```
 
-> Now, let's intereact with the items `93363`
+> Now, let's interact with the items `93363`
 
 ```bash
 # click on the item with id 93363

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -1,8 +1,8 @@
 # Performance
 
-Metarank is a secondary re-ranker: it's an extra **non-free** step in your retrieval process. In a typical scenario, you should expect the following extras:
+Metarank is a secondary reranker: it's an extra **non-free** step in your retrieval process. In a typical scenario, you should expect the following extras:
  
-* Re-ranking latency: 10-30 ms
+* Reranking latency: 10-30 ms
 * Redis memory usage: 1-10 GiB
 * Data import throughput: 1000-3000 events/second.
 
@@ -14,8 +14,8 @@ On a [RankLens](https://github.com/metarank/ranklens) dataset in a [synthetic la
 
 Each Metarank installation is unique, but there are common things affecting the overall latency:
 * [**State encoding format**](configuration/persistence.md#state-encoding-formats): `binary` is faster than `json` due to its compact representation.
-* **Metarank-Redis network latency**: Metarank pulls all features for all re-ranked items in a single large batch. There are no multiple network calls and only a constant overhead. 
-* **Request size**: the more items you ask to re-rank, the more data needs to be loaded.
+* **Metarank-Redis network latency**: Metarank pulls all features for all reranked items in a single large batch. There are no multiple network calls and only a constant overhead. 
+* **Request size**: the more items you ask to rerank, the more data needs to be loaded.
 * [**A number of feature extractors**](configuration/feature-extractors.md): the more per-item features are defined in the config, the more data is loaded during the request processing.
 
 So while planning your installation, expect Metarank to be within **20-30 ms** latency budget.
@@ -37,7 +37,7 @@ Using the same reference [RankLens](https://github.com/metarank/ranklens) datase
 | 2M    | 100K  | 4M       | 8M     | 14.3M        | 3.5GiB            |
 | 4M    | 100K  | 8M       | 16M    | 28.6M        | 7.1GiB            |
 
-Metarank only tracks aggregated data required for the re-ranking and does not store raw events. Therefore, memory usage depends on the following characteristics of your dataset:
+Metarank only tracks aggregated data required for the reranking and does not store raw events. Therefore, memory usage depends on the following characteristics of your dataset:
 
 * **A number of unique users**: per-user click-through events are used as input for the ML model training.
 * **A number of items**: if you define per-item feature extractors (like [`string`](configuration/features/scalar.md#string-extractors) or [`number`](configuration/features/scalar.md#numerical-extractor)), current point-in-time values of used fields are persisted.

--- a/doc/quickstart/quickstart.md
+++ b/doc/quickstart/quickstart.md
@@ -168,7 +168,7 @@ curl http://localhost:8080/rank/xgboost -d '{
 }'
 ```
 
-The API will respond with a list of 100 re-ranked movie ids:
+The API will respond with a list of 100 reranked movie ids:
 ```json5
 {
   "items": [

--- a/doc/tutorial_ranklens.md
+++ b/doc/tutorial_ranklens.md
@@ -1,7 +1,7 @@
 # Personalizing recommendations
 
 This tutorial describes how to make personalized recommendations based on a [Ranklens](https://github.com/metarank/ranklens) dataset.
-The dataset itself is a repackaged version of famous Movielens dataset with recorded real human clitkthroughts on movies.
+The dataset itself is a repackaged version of famous Movielens dataset with recorded real human clickthroughs on movies.
 
 This tutorial reproduces the system running on [demo.metarank.ai](https://demo.metarank.ai).
 
@@ -178,10 +178,10 @@ features:
     periods: [7,30]
  ```
 
-### 1. Data Bootstraping
+### 1. Data Bootstrapping
 
 The bootstrap job will process your incoming events based on a config file and produce a couple of output parts:
-1. `dataset` - backend-agnostic numerical feature values for all the clickhroughs in the dataset
+1. `dataset` - backend-agnostic numerical feature values for all the clickthroughs in the dataset
 2. `features` - snapshot of the latest feature values, which should be used in the inference phase later
 3. `savepoint` - an Apache Flink savepoint to seamlessly continue processing online events after the bootstrap job
 

--- a/doc/tutorial_ranklens.md
+++ b/doc/tutorial_ranklens.md
@@ -202,7 +202,7 @@ java -jar metarank.jar train <config file> xgboost
 
 ### 3. Inference
 
-Run Metarank REST API service to process feedback events and re-rank in real-time. 
+Run Metarank REST API service to process feedback events and rerank in real-time. 
 By default Metarank will be available on `localhost:8080` and you can send feedback events to `http://<ip>:8080/feedback` 
 and get personalized ranking from `http://<ip>:8080/rank/<MODEL_NAME>`. 
 ```shell

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -7,7 +7,7 @@ CONF=$2
 
 java -jar $JAR bootstrap $CONF
 
-echo "Boostrap done"
+echo "Bootstrap done"
 
 java -jar $JAR train $CONF xgboost
 

--- a/src/it/scala/ai/metaranke2e/source/KafkaEventSourceTest.scala
+++ b/src/it/scala/ai/metaranke2e/source/KafkaEventSourceTest.scala
@@ -42,9 +42,9 @@ class KafkaEventSourceTest extends AnyFlatSpec with Matchers with Logging {
     logger.info("Message sent, sleeping")
     Thread.sleep(1000)
     logger.info("Pulling single event from topic")
-    val recieved = KafkaSource(sourceConfig).stream.take(1).compile.toList.unsafeRunSync()
+    val received = KafkaSource(sourceConfig).stream.take(1).compile.toList.unsafeRunSync()
     logger.info("Pull done")
-    recieved shouldBe List(event)
+    received shouldBe List(event)
 
   }
 

--- a/src/main/scala/ai/metarank/config/ConfigEnvSubst.scala
+++ b/src/main/scala/ai/metarank/config/ConfigEnvSubst.scala
@@ -9,12 +9,12 @@ import cats.implicits._
 
 object ConfigEnvSubst extends Logging {
   type Subst = (Config, Map[String, String]) => IO[Config]
-  val subsitutions: List[Subst] = List(
+  val substitutions: List[Subst] = List(
     substTracking,
     substRedisCreds
   )
   def apply(config: Config, env: Map[String, String]): IO[Config] =
-    subsitutions.foldM(config) { case (next, subst) => subst(next, env) }
+    substitutions.foldM(config) { case (next, subst) => subst(next, env) }
 
   def substRedisCreds(config: Config, env: Map[String, String]): IO[Config] =
     (env.get("METARANK_REDIS_USER"), env.get("METARANK_REDIS_PASSWORD")) match {

--- a/src/main/scala/ai/metarank/main/CliArgs.scala
+++ b/src/main/scala/ai/metarank/main/CliArgs.scala
@@ -310,7 +310,7 @@ object CliArgs extends Logging {
       val catThreshold = opt[Double](
         name = "cat-threshold",
         required = false,
-        descr = "min threshold of category frequency, when its considered a catergory (optional, default=0.003)",
+        descr = "min threshold of category frequency, when its considered a category (optional, default=0.003)",
         default = Some(0.003)
       )
 

--- a/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
+++ b/src/main/scala/ai/metarank/ml/rank/LambdaMARTRanker.scala
@@ -286,7 +286,7 @@ object LambdaMARTRanker extends Logging {
             """
               |Cannot train model on an empty dataset. Maybe you forgot to do 'metarank import'?
               |Possible options:
-              |1. You have only interaction or only ranking events. Re-ranking model needs a complete click-throught information. Try running `metarank validate` over your config file and dataset?
+              |1. You have only interaction or only ranking events. Reranking model needs a complete click-through information. Try running `metarank validate` over your config file and dataset?
               |2. Dataset inconsistency. To check for consistency issues, run 'metarank validate --config conf.yml --data data.jsonl.gz',
               |3. You've used an in-memory persistence for import, and after restart the data was lost. Maybe try setting 'state.type=redis'?
               |""".stripMargin

--- a/src/main/scala/ai/metarank/ml/recommend/TrendingRecommender.scala
+++ b/src/main/scala/ai/metarank/ml/recommend/TrendingRecommender.scala
@@ -162,6 +162,6 @@ object TrendingRecommender {
       TrendingConfig(weights, selector.getOrElse(Selector.AcceptSelector()))
     }
   )
-  implicit val trendongConfigEncoder: Encoder[TrendingConfig] = deriveEncoder
-  implicit val trendingConfigCodec: Codec[TrendingConfig]     = Codec.from(trendingConfigDecoder, trendongConfigEncoder)
+  implicit val trendingConfigEncoder: Encoder[TrendingConfig] = deriveEncoder
+  implicit val trendingConfigCodec: Codec[TrendingConfig]     = Codec.from(trendingConfigDecoder, trendingConfigEncoder)
 }

--- a/src/test/scala/ai/metarank/fstore/redis/RedisTrainStoreTest.scala
+++ b/src/test/scala/ai/metarank/fstore/redis/RedisTrainStoreTest.scala
@@ -20,7 +20,7 @@ class RedisTrainStoreTest extends AnyFlatSpec with Matchers with RedisTest {
     result shouldBe Nil
   }
 
-  it should "write and read clickthrougts" in {
+  it should "write and read clickthroughs" in {
     lazy val stream = RedisTrainStore(client, "b", JsonStoreFormat, 90.days)
     val ct          = List(ClickthroughValues(TestClickthrough(List("p1", "p2", "p3"), List("p2")), Nil))
     stream.put(ct).unsafeRunSync()

--- a/src/test/scala/ai/metarank/main/autofeature/model/LambdaMARTConfigGeneratorTest.scala
+++ b/src/test/scala/ai/metarank/main/autofeature/model/LambdaMARTConfigGeneratorTest.scala
@@ -36,7 +36,7 @@ class LambdaMARTConfigGeneratorTest extends AnyFlatSpec with Matchers {
     conf should be(empty)
   }
 
-  it should "accept explicit relevance judgments" in {
+  it should "accept explicit relevance judgements" in {
     val event = TestRankingEvent(List("p1")).copy(items =
       NonEmptyList.of(
         RankItem(ItemId("p1"), label = Some(1)),


### PR DESCRIPTION
Hi team!

I was reading the documentation and noticed a few simple typos, spelling inconsistencies, and sentence semantic mistakes, so I created a PR as my first contribution to this awesome project!

If I'm missing something, please let me know in the comments :)


### changes

* Fix typos.
* Fix spelling inconsistencies.
  * British spelling or American spelling?: The project seemed to prefer the British spelling overall because I standardized on that.
    * `judgment` -> `judgement`
    * `memorize` -> `memorise`
  * Terms representation: Basically, I adapted the expressions that were used more frequently as a result of searching the codebase.
    * `ecommerce` -> `e-commerce`
    * `A\B` -> `A/B`
    * `de-bias` -> `debias`
    * `re-rank` -> `rerank`
    * `hyper-parameter` or `hyperparam` -> `hyperparameter`
  * Inconsistencies in the spelling of `clickthrough` or `click-through` are not included in this PR. It is more extensive in impact.
* Fix sentence semantic mistakes.
* Fix broken link.
* Along with the above, variable names, log text, and comments in the code have also been modified. However, these are only minor modifications and should not cause any problems with the code.