### PR TITLE
ci: migrate to newer docker compose

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
         run: sbt -mem 5000 IntegrationTest/test
 
       - name:  Stop docker-compose
-        run: docker-compose -f .github/compose-connectors.yaml down
+        run: docker compose -f .github/compose-connectors.yaml down
 
       - name: Make docker image
         run: sbt -mem 5000 assembly docker

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         run: mkdir -p .github/tls && .github/generate_keys.sh .github/tls
 
       - name:  Run docker-compose
-        run: docker-compose -f .github/compose-connectors.yaml up -d
+        run: docker compose -f .github/compose-connectors.yaml up -d
 
       - name: Run integration tests
         run: sbt -mem 5000 IntegrationTest/test


### PR DESCRIPTION
As GC Actions upgraded the ubuntu-22.04 image to a newer docker, and `docker-compose`  is now `docker compose`