### PR TITLE
ci: bump macos-12 to macos-14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
             platform: ubuntu-22.04
             architecture: x64
           - jvm: 11
-            platform: macos-12
+            platform: macos-14
             architecture: x64
           - jvm: 11
             platform: macos-14


### PR DESCRIPTION
as macos-12 is deprecated: https://github.com/actions/runner-images/issues/10721