### PR TITLE
[BUG] IRSA fails: missing STS module in classpath (falls back to IMDS/Kubernetes Cluster role)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val root = (project in file("."))
       "io.prometheus"          % "simpleclient_hotspot"     % prometheusVersion,
       "io.prometheus"          % "simpleclient_httpserver"  % prometheusVersion,
       "software.amazon.awssdk" % "s3"                       % awsVersion,
+      "software.amazon.awssdk" % "sts"                      % awsVersion,
       "org.apache.commons"     % "commons-rng-sampling"     % "1.6",
       "org.apache.commons"     % "commons-rng-simple"       % "1.6",
       "io.github.metarank"     % "librec-core"              % "3.0.0-1" excludeAll (


### PR DESCRIPTION
## Description

When running Metarank with train: s3 on EKS using IRSA (annotated ServiceAccount), the AWS SDK fails to assume the IRSA role if IMDS is disabled (AWS_EC2_METADATA_DISABLED=true).
The error observed is:
```
WebIdentityTokenCredentialsProvider(): To use web identity tokens, the 'sts' service module must be on the class path.
```

## Why this change is needed

Without the STS module, the WebIdentity provider in the AWS SDK cannot retrieve credentials from the IRSA token.
As a result:

- If IMDS is enabled, Metarank falls back to the node IAM role, leading to incorrect permissions.
- If IMDS is disabled, S3 access fails entirely.
- We explicitly want to avoid using static credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) and rely on IRSA for security and best practices.

Adding the STS module ensures IRSA works as intended without relying on node roles.

## Impact
- Positive: IRSA authentication works out-of-the-box for train: s3 without IMDS fallback.
- Backwards compatible: No effect on environments not using IRSA.
- Security improvement: Prevents unintended use of node IAM roles when IRSA is configured.
