### PR TITLE
bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Deps._
 lazy val PLATFORM = Option(System.getenv("PLATFORM")).getOrElse("amd64")
 
 ThisBuild / organization := "ai.metarank"
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / version      := "0.7.11"
 
 lazy val root = (project in file("."))
@@ -30,20 +30,20 @@ lazy val root = (project in file("."))
       "11"
     ),
     libraryDependencies ++= Seq(
-      "org.typelevel"        %% "cats-effect"          % "3.6.1",
+      "org.typelevel"        %% "cats-effect"          % "3.7.1",
       "org.scalatest"        %% "scalatest"            % scalatestVersion % "test,it",
       "org.scalactic"        %% "scalactic"            % scalatestVersion % "test,it",
-      "org.scalatestplus"    %% "scalacheck-1-16"      % "3.2.14.0"       % "test,it",
-      "ch.qos.logback"        % "logback-classic"      % "1.5.18",
+      "org.scalatestplus"    %% "scalacheck-1-18"      % "3.2.19.0"       % "test,it",
+      "ch.qos.logback"        % "logback-classic"      % "1.6.3",
       "io.circe"             %% "circe-yaml"           % circeYamlVersion,
       "io.circe"             %% "circe-core"           % circeVersion,
       "io.circe"             %% "circe-generic"        % circeVersion,
       "io.circe"             %% "circe-generic-extras" % circeGenericExtrasVersion,
       "io.circe"             %% "circe-parser"         % circeVersion,
       "com.github.pathikrit" %% "better-files"         % "3.9.2",
-      "org.rogach"           %% "scallop"              % "5.2.0",
+      "org.rogach"           %% "scallop"              % "6.0.0",
       "com.github.blemale"   %% "scaffeine"            % "5.3.0",
-      "org.apache.kafka"      % "kafka-clients"        % "4.0.0",
+      "org.apache.kafka"      % "kafka-clients"        % "4.3.1",
       "org.apache.pulsar"     % "pulsar-client"        % pulsarVersion excludeAll (
         ExclusionRule("org.bouncycastle", "bcprov-ext-jdk18on")
       ),
@@ -52,12 +52,12 @@ lazy val root = (project in file("."))
       "org.http4s"            %% "http4s-ember-server"      % http4sVersion,
       "org.http4s"            %% "http4s-ember-client"      % http4sVersion,
       "org.http4s"            %% "http4s-circe"             % http4sVersion,
-      "org.typelevel"         %% "log4cats-core"            % "2.7.1",
-      "org.typelevel"         %% "log4cats-slf4j"           % "2.7.1",
+      "org.typelevel"         %% "log4cats-core"            % log4catsVersion,
+      "org.typelevel"         %% "log4cats-slf4j"           % log4catsVersion,
       "io.github.metarank"    %% "ltrlib"                   % "0.2.6",
-      "io.github.metarank"     % "lightgbm4j"               % "4.6.0-1",
+      "io.github.metarank"     % "lightgbm4j"               % "4.6.0-2",
       "com.github.ua-parser"   % "uap-java"                 % "1.6.1",
-      "com.snowplowanalytics" %% "scala-referer-parser"     % "2.1.0",
+      "com.snowplowanalytics" %% "scala-referer-parser"     % "4.0.0",
       "org.apache.lucene"      % "lucene-core"              % luceneVersion,
       "org.apache.lucene"      % "lucene-analysis-common"   % luceneVersion,
       "org.apache.lucene"      % "lucene-analysis-icu"      % luceneVersion,
@@ -65,18 +65,19 @@ lazy val root = (project in file("."))
       "org.apache.lucene"      % "lucene-analysis-kuromoji" % luceneVersion,
       "org.apache.lucene"      % "lucene-analysis-stempel"  % luceneVersion,
       "software.amazon.awssdk" % "kinesis"                  % awsVersion,
-      "io.lettuce"             % "lettuce-core"             % "6.7.1.RELEASE",
-      "com.google.guava"       % "guava"                    % "33.4.8-jre",
-      "commons-io"             % "commons-io"               % "2.19.0",
-      "io.sentry"              % "sentry-logback"           % "8.15.1",
+      // lettuce 7.x is built on netty 4.2, which conflicts with netty 4.1 pulled by pulsar/awssdk in the fat jar
+      "io.lettuce"             % "lettuce-core"             % "6.8.2.RELEASE",
+      "com.google.guava"       % "guava"                    % "33.7.1-jre",
+      "commons-io"             % "commons-io"               % "2.22.0",
+      "io.sentry"              % "sentry-logback"           % "8.53.0",
       "com.fasterxml.util"     % "java-merge-sort"          % "1.1.0",
       "io.prometheus"          % "simpleclient"             % prometheusVersion,
       "io.prometheus"          % "simpleclient_hotspot"     % prometheusVersion,
       "io.prometheus"          % "simpleclient_httpserver"  % prometheusVersion,
       "software.amazon.awssdk" % "s3"                       % awsVersion,
       "software.amazon.awssdk" % "sts"                      % awsVersion,
-      "org.apache.commons"     % "commons-rng-sampling"     % "1.6",
-      "org.apache.commons"     % "commons-rng-simple"       % "1.6",
+      "org.apache.commons"     % "commons-rng-sampling"     % "1.7",
+      "org.apache.commons"     % "commons-rng-simple"       % "1.7",
       "io.github.metarank"     % "librec-core"              % "3.0.0-1" excludeAll (
         ExclusionRule("org.nd4j", "guava"),
         ExclusionRule("org.nd4j", "protobuf"),
@@ -84,11 +85,11 @@ lazy val root = (project in file("."))
         ExclusionRule("org.jetbrains.kotlin", "kotlin-stdlib-jdk8"),
         ExclusionRule("org.jetbrains.kotlin", "kotlin-stdlib-common")
       ),
-      "org.rocksdb"               % "rocksdbjni"     % "10.2.1",
+      "org.rocksdb"               % "rocksdbjni"     % "10.10.1.1",
       "org.mapdb"                 % "mapdb"          % "3.1.0" exclude ("net.jpountz.lz4", "lz4"),
       "com.github.jelmerk"        % "hnswlib-core"   % "1.2.1",
-      "org.slf4j"                 % "jcl-over-slf4j" % "2.0.17", // librec uses commons-logging, which is JCL
-      "com.microsoft.onnxruntime" % "onnxruntime"    % "1.22.0",
+      "org.slf4j"                 % "jcl-over-slf4j" % "2.0.18", // librec uses commons-logging, which is JCL
+      "com.microsoft.onnxruntime" % "onnxruntime"    % "1.29.0",
       "ai.djl"                    % "api"            % djlVersion,
       "ai.djl.huggingface"        % "tokenizers"     % djlVersion,
       "co.fs2"                   %% "fs2-core"       % fs2Version,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,18 +1,18 @@
 import sbt._
 
 object Deps {
-  lazy val http4sVersion             = "1.0.0-M44"
-  lazy val log4catsVersion           = "2.4.0"
-  lazy val scalatestVersion          = "3.2.19"
-  lazy val circeVersion              = "0.14.14"
+  lazy val http4sVersion             = "1.0.0-M47"
+  lazy val log4catsVersion           = "2.8.0"
+  lazy val scalatestVersion          = "3.2.20"
+  lazy val circeVersion              = "0.14.16"
   lazy val circeGenericExtrasVersion = "0.14.4"
   lazy val circeYamlVersion          = "0.16.1"
-  lazy val fs2Version                = "3.12.0"
-  lazy val luceneVersion             = "9.12.2"
-  lazy val pulsarVersion             = "4.0.5"
-  lazy val awsVersion                = "2.31.70"
+  lazy val fs2Version                = "3.13.0"
+  lazy val luceneVersion             = "9.12.3"
+  lazy val pulsarVersion             = "4.0.13"
+  lazy val awsVersion                = "2.54.2"
   lazy val prometheusVersion         = "0.16.0"
-  lazy val djlVersion                = "0.28.0"
+  lazy val djlVersion                = "0.36.0"
 
   val httpsDeps = Seq(
     "org.http4s" %% "http4s-dsl"          % http4sVersion,

--- a/src/main/scala/ai/metarank/feature/RefererFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RefererFeature.scala
@@ -20,18 +20,8 @@ import ai.metarank.model.Write.{Put, PutTuple}
 import ai.metarank.model.{Event, FeatureSchema, FeatureValue, Field, FieldName, Key, MValue, ScopeType, Write}
 import ai.metarank.util.Logging
 import better.files.{File, Resource}
-import cats.Id
 import cats.effect.IO
-import com.snowplowanalytics.refererparser.{
-  CreateParser,
-  EmailMedium,
-  InternalMedium,
-  PaidMedium,
-  Parser,
-  SearchMedium,
-  SocialMedium,
-  UnknownMedium
-}
+import com.snowplowanalytics.refererparser.{CreateParser, ExternalReferer, InternalReferer, Parser, UnknownReferer}
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
@@ -48,12 +38,12 @@ case class RefererFeature(schema: RefererSchema, parser: Parser) extends Ranking
   )
 
   val possibleValues = Map(
-    UnknownMedium.value  -> 0,
-    SearchMedium.value   -> 1,
-    InternalMedium.value -> 2,
-    SocialMedium.value   -> 3,
-    EmailMedium.value    -> 4,
-    PaidMedium.value     -> 5
+    "unknown"  -> 0,
+    "search"   -> 1,
+    "internal" -> 2,
+    "social"   -> 3,
+    "email"    -> 4,
+    "paid"     -> 5
   )
 
   override val dim = SingleDim
@@ -86,8 +76,14 @@ case class RefererFeature(schema: RefererSchema, parser: Parser) extends Ranking
           None
       }
       parsed <- parser.parse(ref)
+      medium <- parsed match {
+        case ExternalReferer(medium, _, _) => Some(medium)
+        case InternalReferer               => Some("internal")
+        case UnknownReferer                => Some("unknown")
+        case _                             => None
+      }
     } yield {
-      Put(key, event.timestamp, SString(parsed.medium.value))
+      Put(key, event.timestamp, SString(medium))
     }
   }
 


### PR DESCRIPTION
Update all the minor deps to their latest versions. We still keep JDK, Scala and Lucene intact - will do another PR batch to bump them.