### PR TITLE
fix GH CI: bitnami images and sbt for mac

### DIFF
--- a/.github/compose-connectors.yaml
+++ b/.github/compose-connectors.yaml
@@ -22,7 +22,7 @@ services:
       - '16379:16379'
 
   redistls:
-    image: 'bitnami/redis:7.2.4'
+    image: 'bitnamilegacy/redis:7.2.4'
     volumes:
       - "./tls:/tls"
     ports:
@@ -45,7 +45,7 @@ services:
       - '4567:4567'
 
   kafka:
-    image: docker.io/bitnami/kafka:3.3.2
+    image: docker.io/bitnamilegacy/kafka:3.3.2
     ports:
       - "9092:9092"
     environment:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,11 @@ jobs:
           distribution: 'adopt-hotspot'
           java-version: '11'
 
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+        with:
+          sbt-runner-version: 1.11.7 # sbt 2.x runner refuses to start on JDK 11
+
       - name: Generate TLS certificates
         run: mkdir -p .github/tls && .github/generate_keys.sh .github/tls
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Start Redis on Mac
-      run: brew install redis sbt && brew services start redis
+      run: brew install redis && brew services start redis
       if: runner.os == 'macOS'
 
     - name: Start Redis on Windows
@@ -80,6 +80,11 @@ jobs:
         java-version: ${{ matrix.jvm }}
         architecture: ${{ matrix.architecture }}
         distribution: 'temurin'
+
+    - name: Set up sbt
+      uses: sbt/setup-sbt@v1
+      with:
+        sbt-runner-version: 1.11.7 # sbt 2.x runner refuses to start on JDK 11
 
     - name: Run tests
       run: sbt -mem 3000 test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,6 @@ jobs:
             platform: ubuntu-22.04
             architecture: x64
           - jvm: 11
-            platform: macos-13
-            architecture: x64
-          - jvm: 11
             platform: macos-14
             architecture: aarch64
           - jvm: 11


### PR DESCRIPTION
Unbreak the GHA CI:
* replace unavailable bitnami docker images with `bitnamilegacy` ones
* use sbt 1 for build (as it breaks macos which pulls 2.x and requires JDK17+)
* drop macos13 from CI matrix - GHA has deprecated it long time ago