### PR TITLE
[scala3] remove circe-generic-extras

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,6 @@ lazy val root = (project in file("."))
       "io.circe"             %% "circe-yaml"           % circeYamlVersion,
       "io.circe"             %% "circe-core"           % circeVersion,
       "io.circe"             %% "circe-generic"        % circeVersion,
-      "io.circe"             %% "circe-generic-extras" % circeGenericExtrasVersion,
       "io.circe"             %% "circe-parser"         % circeVersion,
       "com.github.pathikrit" %% "better-files"         % "3.9.2",
       "org.rogach"           %% "scallop"              % "6.0.0",

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -5,7 +5,6 @@ object Deps {
   lazy val log4catsVersion           = "2.8.0"
   lazy val scalatestVersion          = "3.2.20"
   lazy val circeVersion              = "0.14.16"
-  lazy val circeGenericExtrasVersion = "0.14.4"
   lazy val circeYamlVersion          = "0.16.1"
   lazy val fs2Version                = "3.13.0"
   lazy val luceneVersion             = "10.5.1"

--- a/src/main/scala/ai/metarank/config/CoreConfig.scala
+++ b/src/main/scala/ai/metarank/config/CoreConfig.scala
@@ -2,7 +2,7 @@ package ai.metarank.config
 
 import ai.metarank.config.CoreConfig.{ClickthroughJoinConfig, ImportConfig, TrackingConfig}
 import cats.effect.IO
-import io.circe.generic.semiauto.{deriveEncoder, deriveFor}
+import io.circe.generic.semiauto.deriveEncoder
 import io.circe.{Decoder, Encoder}
 
 import scala.concurrent.duration._

--- a/src/main/scala/ai/metarank/config/InputConfig.scala
+++ b/src/main/scala/ai/metarank/config/InputConfig.scala
@@ -4,9 +4,7 @@ import ai.metarank.config.InputConfig.FileInputConfig.SortingType
 import ai.metarank.config.InputConfig.FileInputConfig.SortingType.{SortByName, SortByTime}
 import ai.metarank.source.format.JsonFormat
 import cats.data.NonEmptyList
-import io.circe.{Codec, Decoder, Encoder, Json}
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
@@ -85,15 +83,86 @@ object InputConfig {
       format: SourceFormat = JsonFormat
   ) extends InputConfig
 
-  implicit val conf: Configuration = Configuration.default
-    .withDiscriminator("type")
-    .withDefaults
-    .copy(transformConstructorNames = {
-      case "FileInputConfig"    => "file"
-      case "KafkaInputConfig"   => "kafka"
-      case "PulsarInputConfig"  => "pulsar"
-      case "KinesisInputConfig" => "kinesis"
-    })
-  implicit val eventSourceDecoder: Decoder[InputConfig] = deriveConfiguredDecoder
+  implicit val kafkaDecoder: Decoder[KafkaInputConfig] = Decoder.instance(c =>
+    for {
+      brokers <- c.downField("brokers").as[NonEmptyList[String]]
+      topic   <- c.downField("topic").as[String]
+      groupId <- c.downField("groupId").as[String]
+      offset  <- c.downField("offset").as[Option[SourceOffset]]
+      options <- c.downField("options").as[Option[Map[String, String]]]
+      format  <- c.getOrElse[SourceFormat]("format")(JsonFormat)
+    } yield KafkaInputConfig(
+      brokers = brokers,
+      topic = topic,
+      groupId = groupId,
+      offset = offset,
+      options = options,
+      format = format
+    )
+  )
+
+  implicit val fileDecoder: Decoder[FileInputConfig] = Decoder.instance(c =>
+    for {
+      path   <- c.downField("path").as[String]
+      offset <- c.getOrElse[SourceOffset]("offset")(SourceOffset.Earliest)
+      format <- c.getOrElse[SourceFormat]("format")(JsonFormat)
+      sort   <- c.getOrElse[SortingType]("sort")(SortByName)
+    } yield FileInputConfig(path = path, offset = offset, format = format, sort = sort)
+  )
+
+  implicit val pulsarDecoder: Decoder[PulsarInputConfig] = Decoder.instance(c =>
+    for {
+      serviceUrl       <- c.downField("serviceUrl").as[String]
+      adminUrl         <- c.downField("adminUrl").as[String]
+      topic            <- c.downField("topic").as[String]
+      subscriptionName <- c.downField("subscriptionName").as[String]
+      subscriptionType <- c.downField("subscriptionType").as[String]
+      offset           <- c.downField("offset").as[Option[SourceOffset]]
+      options          <- c.downField("options").as[Option[Map[String, String]]]
+      format           <- c.getOrElse[SourceFormat]("format")(JsonFormat)
+    } yield PulsarInputConfig(
+      serviceUrl = serviceUrl,
+      adminUrl = adminUrl,
+      topic = topic,
+      subscriptionName = subscriptionName,
+      subscriptionType = subscriptionType,
+      offset = offset,
+      options = options,
+      format = format
+    )
+  )
+
+  implicit val kinesisDecoder: Decoder[KinesisInputConfig] = Decoder.instance(c =>
+    for {
+      topic                <- c.downField("topic").as[String]
+      offset               <- c.downField("offset").as[SourceOffset]
+      region               <- c.downField("region").as[String]
+      endpoint             <- c.downField("endpoint").as[Option[String]]
+      skipCertVerification <- c.getOrElse[Boolean]("skipCertVerification")(false)
+      getRecordsPeriod     <- c.getOrElse[FiniteDuration]("getRecordsPeriod")(200.millis)
+      sleepOnEmptyPeriod   <- c.getOrElse[FiniteDuration]("sleepOnEmptyPeriod")(1.second)
+      format               <- c.getOrElse[SourceFormat]("format")(JsonFormat)
+    } yield KinesisInputConfig(
+      topic = topic,
+      offset = offset,
+      region = region,
+      endpoint = endpoint,
+      skipCertVerification = skipCertVerification,
+      getRecordsPeriod = getRecordsPeriod,
+      sleepOnEmptyPeriod = sleepOnEmptyPeriod,
+      format = format
+    )
+  )
+
+  implicit val eventSourceDecoder: Decoder[InputConfig] = Decoder.instance(c =>
+    c.downField("type").as[String] match {
+      case Left(_)          => Left(DecodingFailure("required field 'type' missing in input config", c.history))
+      case Right("file")    => fileDecoder.tryDecode(c)
+      case Right("kafka")   => kafkaDecoder.tryDecode(c)
+      case Right("pulsar")  => pulsarDecoder.tryDecode(c)
+      case Right("kinesis") => kinesisDecoder.tryDecode(c)
+      case Right(other)     => Left(DecodingFailure(s"input type '$other' is not supported", c.history))
+    }
+  )
 
 }

--- a/src/main/scala/ai/metarank/feature/RateFeature.scala
+++ b/src/main/scala/ai/metarank/feature/RateFeature.scala
@@ -4,7 +4,7 @@ import ai.metarank.feature.BaseFeature.ItemFeature
 import ai.metarank.feature.RateFeature.RateFeatureSchema
 import ai.metarank.fstore.Persistence
 import ai.metarank.model.Dimension.VectorDim
-import ai.metarank.model.Event.{InteractionEvent, ItemEvent, RankItem, RankingEvent, conf}
+import ai.metarank.model.Event.{InteractionEvent, ItemEvent, RankItem, RankingEvent}
 import ai.metarank.model.Feature.FeatureConfig
 import ai.metarank.model.Feature.PeriodicCounterFeature.{PeriodRange, PeriodicCounterConfig}
 import ai.metarank.model.Feature.ScalarFeature.ScalarConfig

--- a/src/main/scala/ai/metarank/model/Event.scala
+++ b/src/main/scala/ai/metarank/model/Event.scala
@@ -2,10 +2,8 @@ package ai.metarank.model
 
 import ai.metarank.model.Field.NumberField
 import cats.data.NonEmptyList
-import io.circe.generic.extras.Configuration
-import io.circe.{Codec, Decoder, DecodingFailure, Encoder}
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
 import io.circe.generic.semiauto._
-import io.circe.generic.extras.semiauto.{deriveConfiguredCodec, deriveConfiguredDecoder, deriveConfiguredEncoder}
 import ai.metarank.model.Identifier._
 
 import java.time.format.DateTimeFormatter
@@ -79,7 +77,6 @@ object Event {
         .map(Timestamp.apply),
       encodeA = Encoder.encodeString.contramap(_.ts.toString)
     )
-    implicit val conf: Configuration                 = Configuration.default.withDefaults
     implicit val relevancyEncoder: Encoder[RankItem] = deriveEncoder
     implicit val relevancyDecoder: Decoder[RankItem] = Decoder.instance(c =>
       for {
@@ -93,10 +90,72 @@ object Event {
     )
     implicit val relevancyCodec: Codec[RankItem] = Codec.from(relevancyDecoder, relevancyEncoder)
 
-    implicit val itemCodec: Codec[ItemEvent]               = deriveConfiguredCodec
-    implicit val userCodec: Codec[UserEvent]               = deriveConfiguredCodec
-    implicit val rankingCodec: Codec[RankingEvent]         = deriveConfiguredCodec
-    implicit val interactionCodec: Codec[InteractionEvent] = deriveConfiguredCodec
+    implicit val itemCodec: Codec[ItemEvent] = Codec.from(
+      decodeA = Decoder.instance(c =>
+        for {
+          id        <- c.downField("id").as[EventId]
+          item      <- c.downField("item").as[ItemId]
+          timestamp <- c.downField("timestamp").as[Timestamp]
+          fields    <- c.getOrElse[List[Field]]("fields")(Nil)
+        } yield ItemEvent(id = id, item = item, timestamp = timestamp, fields = fields)
+      ),
+      encodeA = deriveEncoder
+    )
+    implicit val userCodec: Codec[UserEvent] = Codec.from(
+      decodeA = Decoder.instance(c =>
+        for {
+          id        <- c.downField("id").as[EventId]
+          user      <- c.downField("user").as[UserId]
+          timestamp <- c.downField("timestamp").as[Timestamp]
+          fields    <- c.getOrElse[List[Field]]("fields")(Nil)
+        } yield UserEvent(id = id, user = user, timestamp = timestamp, fields = fields)
+      ),
+      encodeA = deriveEncoder
+    )
+    implicit val rankingCodec: Codec[RankingEvent] = Codec.from(
+      decodeA = Decoder.instance(c =>
+        for {
+          id        <- c.downField("id").as[EventId]
+          timestamp <- c.downField("timestamp").as[Timestamp]
+          user      <- c.downField("user").as[Option[UserId]]
+          session   <- c.downField("session").as[Option[SessionId]]
+          fields    <- c.getOrElse[List[Field]]("fields")(Nil)
+          items     <- c.downField("items").as[NonEmptyList[RankItem]]
+        } yield RankingEvent(
+          id = id,
+          timestamp = timestamp,
+          user = user,
+          session = session,
+          fields = fields,
+          items = items
+        )
+      ),
+      encodeA = deriveEncoder
+    )
+    implicit val interactionCodec: Codec[InteractionEvent] = Codec.from(
+      decodeA = Decoder.instance(c =>
+        for {
+          id        <- c.downField("id").as[EventId]
+          item      <- c.downField("item").as[ItemId]
+          timestamp <- c.downField("timestamp").as[Timestamp]
+          ranking   <- c.downField("ranking").as[Option[EventId]]
+          user      <- c.downField("user").as[Option[UserId]]
+          session   <- c.downField("session").as[Option[SessionId]]
+          tpe       <- c.downField("type").as[String]
+          fields    <- c.getOrElse[List[Field]]("fields")(Nil)
+        } yield InteractionEvent(
+          id = id,
+          item = item,
+          timestamp = timestamp,
+          ranking = ranking,
+          user = user,
+          session = session,
+          `type` = tpe,
+          fields = fields
+        )
+      ),
+      encodeA = deriveEncoder
+    )
   }
 
   import EventCodecs.itemCodec
@@ -104,17 +163,12 @@ object Event {
   import EventCodecs.rankingCodec
   import EventCodecs.interactionCodec
 
-  implicit val conf: Configuration = Configuration.default
-    .withDiscriminator("event")
-    .withKebabCaseMemberNames
-    .copy(transformConstructorNames = {
-      case "ItemEvent"        => "item"
-      case "UserEvent"        => "user"
-      case "RankingEvent"     => "ranking"
-      case "InteractionEvent" => "interaction"
-    })
-
-  implicit val eventEncoder: Encoder[Event] = deriveConfiguredEncoder
+  implicit val eventEncoder: Encoder[Event] = Encoder.instance {
+    case e: ItemEvent        => itemCodec(e).deepMerge(Json.obj("event" -> Json.fromString("item")))
+    case e: UserEvent        => userCodec(e).deepMerge(Json.obj("event" -> Json.fromString("user")))
+    case e: RankingEvent     => rankingCodec(e).deepMerge(Json.obj("event" -> Json.fromString("ranking")))
+    case e: InteractionEvent => interactionCodec(e).deepMerge(Json.obj("event" -> Json.fromString("interaction")))
+  }
   implicit val eventDecoder: Decoder[Event] = Decoder.instance(c =>
     c.downField("event").as[String] match {
       case Left(error) => Left(DecodingFailure(s"required field 'event' missing in JSON", c.history))

--- a/src/main/scala/ai/metarank/model/FeatureValue.scala
+++ b/src/main/scala/ai/metarank/model/FeatureValue.scala
@@ -4,7 +4,6 @@ import ai.metarank.model.FeatureValue.BoundedListValue.TimeValue
 import ai.metarank.model.FeatureValue.PeriodicCounterValue.PeriodicValue
 import io.circe._
 import io.circe.generic.semiauto._
-import shapeless.Lazy
 
 import java.util
 import scala.concurrent.duration.FiniteDuration


### PR DESCRIPTION
A yet another dependency cleanup for scala3 migration. No user-visible changes.