### PR TITLE
fix a bunch of sbt build warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,15 @@ ThisBuild / scalaVersion := "3.8.4"
 ThisBuild / dynverVTagPrefix := false // tags are "0.8.0", not "v0.8.0"
 ThisBuild / dynverSeparator  := "-"   // dynver's default "+" is not allowed in docker tags
 
+// these DockerPlugin/UniversalPlugin defaults are unused because dockerCommands
+// and Docker/mappings are fully overridden below
+Global / excludeLintKeys ++= Set(
+  Universal / executableScriptName,
+  UniversalDocs / name,
+  UniversalSrc / name,
+  dockerEntrypoint
+)
+
 lazy val It = config("it").extend(Test)
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
before:
```
$ sbt clean compile
[info] welcome to sbt 2.0.7 (Eclipse Adoptium Java 21.0.12)
[info] loading project definition from /home/shutty/private/code/metarank/project
[info] set current project to metarank (in build file:/home/shutty/private/code/metarank/)
[warn] there are 4 keys that are not used by any other settings/tasks:
[warn]  
[warn] * root / Universal / executableScriptName
[warn]   +- Universal / executableScriptName := executableScriptName.value:73
[warn] * root / Universal-docs / name
[warn]   +- UniversalDocs / name := (Universal / name).value:69
[warn] * root / Universal-src / name
[warn]   +- UniversalSrc / name := (Universal / name).value:70
[warn] * root / dockerEntrypoint
[warn]   +- dockerEntrypoint := Seq(s"${(Docker / defaultLinuxInstallLocation).value}/bin/${executableScriptName.value}"):147
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
[info] Executing in batch mode. For better performance use sbt's shell
[success] elapsed time: 0 s, cache 100%, 2 disk cache hits
[success] elapsed time: 2 s, cache 100%, 15 disk cache hits
```

after:
```
$ sbt compile
[info] welcome to sbt 2.0.7 (Eclipse Adoptium Java 21.0.12)
[info] loading project definition from /home/shutty/private/code/metarank/project
[info] set current project to metarank (in build file:/home/shutty/private/code/metarank/)
[info] Executing in batch mode. For better performance use sbt's shell
[info] compiling 2 Scala sources to /home/shutty/private/code/metarank/target/out/jvm/scala-3.8.4/metarank/classes ...
[success] elapsed time: 6 s, cache 86%, 13 disk cache hits, 2 onsite tasks
```