### PR TITLE
Paginate `S3TrainStore.listKeys` so train reads beyond 1000 parts

### DIFF
--- a/src/it/scala/ai/metaranke2e/ct/S3TrainStoreTest.scala
+++ b/src/it/scala/ai/metaranke2e/ct/S3TrainStoreTest.scala
@@ -4,10 +4,14 @@ import ai.metarank.config.TrainConfig.CompressionType.{GzipCompressionType, Zstd
 import ai.metarank.config.TrainConfig.{CompressionType, S3TrainConfig}
 import ai.metarank.fstore.clickthrough.S3TrainStore
 import ai.metarank.util.TestClickthroughValues
+import cats.effect.IO
+import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.global
 import cats.implicits.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.core.async.AsyncRequestBody
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
 import scala.util.Random
 
@@ -59,5 +63,25 @@ class S3TrainStoreTest extends AnyFlatSpec with Matchers {
     val zstdStore = makeStore(config(prefix, compress = ZstdCompressionType))
     val read      = zstdStore.getall().compile.toList.unsafeRunSync()
     read shouldBe events
+  }
+
+  it should "list keys past the 1000-key page limit" in {
+    val prefix = s"test_${Random.nextInt(100000)}"
+    val store  = makeStore(config(prefix))
+    val count  = 1001
+    (0 until count).toList
+      .parTraverseN(16)(i =>
+        IO.fromCompletableFuture(
+          IO(
+            store.client.putObject(
+              PutObjectRequest.builder().bucket("bucket").key(s"$prefix/part_$i.bin").build(),
+              AsyncRequestBody.fromString("x")
+            )
+          )
+        )
+      )
+      .unsafeRunSync()
+
+    store.listKeys().unsafeRunSync().size shouldBe count
   }
 }

--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -21,7 +21,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model.{
   GetObjectRequest,
   HeadObjectRequest,
-  ListObjectsRequest,
+  ListObjectsV2Request,
   PutObjectRequest
 }
 import software.amazon.awssdk.services.s3.S3AsyncClient
@@ -99,13 +99,28 @@ case class S3TrainStore(
     _ <- info(s"downloaded part $key size=${FileUtils.byteCountToDisplaySize(size)}")
   } yield {}
 
-  def listKeys(): IO[List[String]] = for {
-    request  <- IO(ListObjectsRequest.builder().bucket(conf.bucket).prefix(conf.prefix).build())
-    response <- IO.fromCompletableFuture(IO(client.listObjects(request)))
-    files    <- IO(response.contents().asScala.map(_.key()).toList.sorted)
-    _        <- info(s"S3 list objects: count=${files.size} values=$files")
-  } yield {
-    files
+  def listKeys(): IO[List[String]] = {
+    // S3 caps a list response at 1000 keys
+    def loop(token: Option[String], acc: List[String]): IO[List[String]] = for {
+      request <- IO {
+        val builder = ListObjectsV2Request.builder().bucket(conf.bucket).prefix(conf.prefix)
+        token.foreach(builder.continuationToken)
+        builder.build()
+      }
+      response <- IO.fromCompletableFuture(IO(client.listObjectsV2(request)))
+      keys = acc ++ response.contents().asScala.map(_.key()).toList
+      // isTruncated and nextContinuationToken are boxed and may be absent from the response
+      next = Option(response.nextContinuationToken()).filter(_ => Option(response.isTruncated).exists(_.booleanValue))
+      result <- next match {
+        case Some(token) => loop(Some(token), keys)
+        case None        => IO.pure(keys)
+      }
+    } yield result
+
+    for {
+      files <- loop(None, Nil).map(_.sorted)
+      _     <- info(s"S3 list objects: count=${files.size}")
+    } yield files
   }
 
   def tick(): IO[Unit] = for {


### PR DESCRIPTION
`listKeys` issued a single `ListObjects` call. But S3 caps a list response at 1000 keys, so once
a bucket holds more than 1000 train parts, the extras were silently dropped from the training
set.

This switches to `ListObjectsV2` and follows the continuation token. It also drops the full key list from the log line. (At >1000 keys, it was unusable.)

~The repo has no S3 test double so far. (The only S3 test, `S3TrainBufferTest`, covers the in-memory `Buffer`). Creating the mock infrastructure would make this PR much larger. Let me know if you would like me to do that.~ → Meanwhile, I’ve found the S3 integration tests and added one that writes 1001 objects and asserts listKeys returns all of them.