### PR TITLE
Deduplicate train events by ID when reading S3 parts

### DIFF
--- a/doc/configuration/overview.md
+++ b/doc/configuration/overview.md
@@ -110,6 +110,8 @@ train:
   partInterval: 1h            # optional, default: 1h
   endpoint: <endpoint URI>    # optional, custom S3 endpoint
   format: json | binary       # optional, default: binary
+  deduplicate: false          # optional, default: false, drop records whose event id was
+  # already seen while reading, for buckets holding parts uploaded more than once
   awsKey: "<key>"             # optional, you should prefer setting
   # AWS_KEY_ID and AWS_SECRET_KEY_ID env vars
   awsKeySecret: "<secret>"    # optional

--- a/src/it/scala/ai/metaranke2e/ct/S3TrainStoreTest.scala
+++ b/src/it/scala/ai/metaranke2e/ct/S3TrainStoreTest.scala
@@ -50,6 +50,33 @@ class S3TrainStoreTest extends AnyFlatSpec with Matchers {
     read should contain theSameElementsAs events
   }
 
+  it should "keep records with repeating ids by default, and drop them when deduplicate is set" in {
+    val prefix = s"test_${Random.nextInt(100000)}"
+    val events = List.fill(100)(ct)
+    val plain  = makeStore(config(prefix))
+    plain.put(events).unsafeRunSync()
+    plain.flush().unsafeRunSync()
+    plain.getall().compile.toList.unsafeRunSync() shouldBe events
+
+    val dedup = makeStore(config(prefix).copy(deduplicate = true))
+    dedup.getall().compile.toList.unsafeRunSync() shouldBe List(ct)
+  }
+
+  it should "drop records duplicated across parts when deduplicate is set" in {
+    val prefix = s"test_${Random.nextInt(100000)}"
+    val events = (0 until 10).map(i => TestClickthroughValues(List(s"a$i", s"b$i"))).toList
+    val writer = makeStore(config(prefix))
+    // The same batch written twice, as a retried upload or a flush racing a restart leaves it
+    writer.put(events).unsafeRunSync()
+    writer.flush().unsafeRunSync()
+    writer.put(events).unsafeRunSync()
+    writer.flush().unsafeRunSync()
+
+    makeStore(config(prefix)).getall().compile.toList.unsafeRunSync() should have size 20
+    val dedup = makeStore(config(prefix).copy(deduplicate = true))
+    dedup.getall().compile.toList.unsafeRunSync() should contain theSameElementsAs events
+  }
+
   it should "read parts written with a different compression config" in {
     val prefix    = s"test_${Random.nextInt(100000)}"
     val gzipStore = makeStore(config(prefix, compress = GzipCompressionType))

--- a/src/main/scala/ai/metarank/config/TrainConfig.scala
+++ b/src/main/scala/ai/metarank/config/TrainConfig.scala
@@ -48,7 +48,8 @@ object TrainConfig {
       partSizeEvents: Int = 1024,
       partInterval: FiniteDuration = 1.hour,
       endpoint: Option[String] = None,
-      format: StoreFormat = BinaryStoreFormat
+      format: StoreFormat = BinaryStoreFormat,
+      deduplicate: Boolean = false
   ) extends TrainConfig
   given s3TrainConfigDecoder: Decoder[S3TrainConfig] = Decoder.instance(c =>
     for {
@@ -63,6 +64,7 @@ object TrainConfig {
       partInterval    <- c.downField("partInterval").as[Option[FiniteDuration]]
       endpoint        <- c.downField("endpoint").as[Option[String]]
       format          <- c.downField("format").as[Option[StoreFormat]]
+      deduplicate     <- c.downField("deduplicate").as[Option[Boolean]]
     } yield {
       S3TrainConfig(
         key,
@@ -75,7 +77,8 @@ object TrainConfig {
         batchSizeEvents.getOrElse(1024),
         partInterval.getOrElse(1.hour),
         endpoint,
-        format.getOrElse(BinaryStoreFormat)
+        format.getOrElse(BinaryStoreFormat),
+        deduplicate.getOrElse(false)
       )
     }
   )

--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -4,7 +4,7 @@ import ai.metarank.config.TrainConfig.{CompressionType, S3TrainConfig}
 import ai.metarank.fstore.TrainStore
 import ai.metarank.fstore.clickthrough.S3TrainStore.{Buffer, format}
 import ai.metarank.fstore.codec.VCodec
-import ai.metarank.model.TrainValues
+import ai.metarank.model.{EventId, TrainValues}
 import ai.metarank.util.Logging
 import cats.effect.{IO, Ref}
 import cats.effect.kernel.Resource
@@ -50,23 +50,28 @@ case class S3TrainStore(
   } yield {}
 
   override def getall(): fs2.Stream[IO, TrainValues] =
-    fs2.Stream
-      .evalSeq(listKeys())
-      .evalFilter(key =>
-        CompressionType.fromKey(key) match {
-          case Some(_) => IO.pure(true)
-          case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
-        }
-      )
-      .flatMap(key =>
-        // A single truncated/corrupt part (e.g. left behind by an interrupted or
-        // concurrent write) must not abort the whole training run: log it and skip
-        // the rest of that part, keeping the records already read from it and every
-        // other part.
-        getPart(key).handleErrorWith(e =>
-          fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
+    // Suspend so each materialisation of the stream gets its own seen-set
+    fs2.Stream.suspend {
+      val seen = scala.collection.mutable.HashSet.empty[EventId]
+      fs2.Stream
+        .evalSeq(listKeys())
+        .evalFilter(key =>
+          CompressionType.fromKey(key) match {
+            case Some(_) => IO.pure(true)
+            case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
+          }
         )
-      )
+        .flatMap(key =>
+          // A single truncated/corrupt part (e.g. left behind by an interrupted or
+          // concurrent write) must not abort the whole training run: log it and skip
+          // the rest of that part, keeping the records already read from it and every
+          // other part.
+          getPart(key).handleErrorWith(e =>
+            fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
+          )
+        )
+        .filter(tv => seen.add(tv.id))
+    }
 
   def getPart(key: String): fs2.Stream[IO, TrainValues] = {
     fs2.Stream

--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -49,29 +49,33 @@ case class S3TrainStore(
     _ <- maybeFlush()
   } yield {}
 
-  override def getall(): fs2.Stream[IO, TrainValues] =
-    // Suspend so each materialisation of the stream gets its own seen-set
-    fs2.Stream.suspend {
-      val seen = scala.collection.mutable.HashSet.empty[EventId]
-      fs2.Stream
-        .evalSeq(listKeys())
-        .evalFilter(key =>
-          CompressionType.fromKey(key) match {
-            case Some(_) => IO.pure(true)
-            case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
-          }
+  override def getall(): fs2.Stream[IO, TrainValues] = {
+    val parts = fs2.Stream
+      .evalSeq(listKeys())
+      .evalFilter(key =>
+        CompressionType.fromKey(key) match {
+          case Some(_) => IO.pure(true)
+          case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
+        }
+      )
+      .flatMap(key =>
+        // A single truncated/corrupt part (e.g. left behind by an interrupted or
+        // concurrent write) must not abort the whole training run: log it and skip
+        // the rest of that part, keeping the records already read from it and every
+        // other part.
+        getPart(key).handleErrorWith(e =>
+          fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
         )
-        .flatMap(key =>
-          // A single truncated/corrupt part (e.g. left behind by an interrupted or
-          // concurrent write) must not abort the whole training run: log it and skip
-          // the rest of that part, keeping the records already read from it and every
-          // other part.
-          getPart(key).handleErrorWith(e =>
-            fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
-          )
-        )
-        .filter(tv => seen.add(tv.id))
-    }
+      )
+
+    if (conf.deduplicate)
+      // Suspend so each materialisation of the stream gets its own seen-set
+      fs2.Stream.suspend {
+        val seen = scala.collection.mutable.HashSet.empty[EventId]
+        parts.filter(tv => seen.add(tv.id))
+      }
+    else parts
+  }
 
   def getPart(key: String): fs2.Stream[IO, TrainValues] = {
     fs2.Stream


### PR DESCRIPTION
A part uploaded twice (a retried `putObject`, or a flush racing a restart) contributes its
records to training more than once, overweighting them. `getall` now filters on a seen-set of
`EventId`, created inside `Stream.suspend`.

#### Discussion points
1. ~The seen-set is unbounded, so peak memory scales with distinct event count. Should we offer a config
  flag?~ → Added the flag
2. The deduplication only applies to `S3TrainStore`. Theoretically, `FileTrainStore` and `RedisTrainStore` have the same exposure. I found the implementation easier in the S3 part, and it’s the only place duplication materialised in my case. Let me know if you want me to move the deduplication to `TrainStore` or in `Train`.