### PR TITLE
Add cadence and user selectors

### DIFF
--- a/doc/configuration/supported-ranking-models.md
+++ b/doc/configuration/supported-ranking-models.md
@@ -131,6 +131,31 @@ selector:
   maxItems: 20 # both min and max are optional
 ```
 
+* **User selector**: only accept click-through events belonging to a single user. Useful to single out a known bot or service account:
+```yaml
+selector:
+  user: monitoring-bot
+```
+
+* **Cadence selector**: only accept click-through events landing within a fixed slot of a repeating period. Periods are aligned to the epoch, so a 300 second period starts on every wall-clock 5-minute mark in UTC. Both bounds are inclusive and must satisfy `0 <= secondFrom <= secondTo < periodSeconds`:
+```yaml
+selector:
+  periodSeconds: 300 # the period repeats every 5 minutes
+  secondFrom: 90     # accept events from 90s into the period
+  secondTo: 110      # up to and including 110s into the period
+```
+This is mostly useful in combination with NOT, to drop synthetic traffic from a scheduler firing on a strict interval:
+```yaml
+selector:
+  not:
+    and:
+      - minItems: 2
+        maxItems: 2
+      - periodSeconds: 300
+        secondFrom: 90
+        secondTo: 110
+```
+
 * **AND/OR/NOT selector**: combine multiple selectors within a single boolean combination:
 ```yaml
 selector:

--- a/src/main/scala/ai/metarank/config/Selector.scala
+++ b/src/main/scala/ai/metarank/config/Selector.scala
@@ -66,7 +66,30 @@ object Selector {
     override def accept(event: Clickthrough): Boolean = accept
   }
 
+  case class UserSelector(user: String) extends Selector {
+    override def accept(event: Clickthrough): Boolean = event.user.exists(_.value == user)
+  }
+
+  // Selects clickthroughs landing in a fixed slot of a repeating period, to isolate traffic
+  // from schedulers firing on a strict interval. Periods are aligned to the epoch, so a
+  // 300s period starts on every wall-clock 5-minute mark in UTC.
+  case class CadenceSelector(periodSeconds: Int, secondFrom: Int, secondTo: Int) extends Selector {
+    override def accept(event: Clickthrough): Boolean = {
+      val offset = Math.floorMod(Math.floorDiv(event.ts.ts, 1000L), periodSeconds.toLong)
+      (offset >= secondFrom) && (offset <= secondTo)
+    }
+  }
+
   given fieldSelectorCodec: Codec[FieldSelector] = deriveCodec
+
+  given userSelectorCodec: Codec[UserSelector] = deriveCodec
+
+  given cadenceEncoder: Encoder[CadenceSelector] = deriveEncoder
+  given cadenceDecoder: Decoder[CadenceSelector] = deriveDecoder[CadenceSelector].ensure(
+    s => (s.periodSeconds > 0) && (s.secondFrom >= 0) && (s.secondTo >= s.secondFrom) && (s.secondTo < s.periodSeconds),
+    "cadence selector needs 0 <= secondFrom <= secondTo < periodSeconds"
+  )
+  given cadenceCodec: Codec[CadenceSelector] = Codec.from(cadenceDecoder, cadenceEncoder)
 
   given rankingLengthEncoder: Encoder[RankingLengthSelector] = deriveEncoder
   given rankingLengthDecoder: Decoder[RankingLengthSelector] = deriveDecoder[RankingLengthSelector].ensure(
@@ -98,6 +121,8 @@ object Selector {
       c,
       NonEmptyList.of(
         rankingLengthCodec,
+        cadenceCodec,
+        userSelectorCodec,
         maxPositionCodec,
         fieldSelectorCodec,
         sampleSelectorCodec,
@@ -129,6 +154,8 @@ object Selector {
     case a: AcceptSelector              => acceptSelectorCodec(a)
     case m: InteractionPositionSelector => maxPositionCodec(m)
     case r: RankingLengthSelector       => rankingLengthCodec(r)
+    case u: UserSelector                => userSelectorCodec(u)
+    case c: CadenceSelector             => cadenceCodec(c)
   }
   given selectorCodec: Codec[Selector] = Codec.from(selectorDecoder, selectorEncoder)
 

--- a/src/test/scala/ai/metarank/config/SelectorTest.scala
+++ b/src/test/scala/ai/metarank/config/SelectorTest.scala
@@ -2,12 +2,17 @@ package ai.metarank.config
 
 import ai.metarank.config.Selector.{
   AndSelector,
+  CadenceSelector,
   FieldSelector,
   InteractionPositionSelector,
+  NotSelector,
   OrSelector,
-  RankingLengthSelector
+  RankingLengthSelector,
+  UserSelector
 }
 import ai.metarank.model.Field.StringField
+import ai.metarank.model.Identifier.UserId
+import ai.metarank.model.Timestamp
 import ai.metarank.util.TestClickthrough
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -56,5 +61,43 @@ class SelectorTest extends AnyFlatSpec with Matchers {
     a.accept(ct1) shouldBe true
     a.accept(ct2) shouldBe true
     a.accept(ct3) shouldBe false
+  }
+
+  it should "accept events with user selector" in {
+    val ct1 = TestClickthrough(List("p1"), List("p1")).copy(user = Some(UserId("monitoring-bot")))
+    val ct2 = TestClickthrough(List("p1"), List("p1"))
+    val ct3 = TestClickthrough(List("p1"), List("p1")).copy(user = None)
+    val us  = UserSelector("monitoring-bot")
+    us.accept(ct1) shouldBe true
+    us.accept(ct2) shouldBe false
+    us.accept(ct3) shouldBe false
+  }
+
+  it should "accept events landing in the cadence slot" in {
+    val cs = CadenceSelector(300, 90, 110)
+    // 10:11:36 UTC -> minute 11 is 1 mod 5, so 96s into the 5-minute period
+    val inSlot = TestClickthrough(List("p1", "p2"), List("p1"))
+      .copy(ts = Timestamp.date(2026, 8, 19, 10, 11, 36))
+    // 10:13:20 UTC -> 200s into the period
+    val outOfSlot = TestClickthrough(List("p1", "p2"), List("p1"))
+      .copy(ts = Timestamp.date(2026, 8, 19, 10, 13, 20))
+    cs.accept(inSlot) shouldBe true
+    cs.accept(outOfSlot) shouldBe false
+  }
+
+  it should "exclude synthetic traffic with cadence and ranking length combined" in {
+    // the shape a monitoring bot leaves: a fixed-size ranking on a strict 5-minute tick
+    val bot = TestClickthrough(List("p1", "p2"), List("p1"))
+      .copy(ts = Timestamp.date(2026, 8, 19, 10, 11, 36))
+    // a genuine ranking of the same size that happens to be off-cadence
+    val realSmall = TestClickthrough(List("p1", "p2"), List("p1"))
+      .copy(ts = Timestamp.date(2026, 8, 19, 10, 13, 20))
+    // a genuine ranking on the tick, but with a full slate of items
+    val realOnTick = TestClickthrough(List("p1", "p2", "p3", "p4"), List("p1"))
+      .copy(ts = Timestamp.date(2026, 8, 19, 10, 11, 36))
+    val keep = NotSelector(AndSelector(List(RankingLengthSelector(Some(2), Some(2)), CadenceSelector(300, 90, 110))))
+    keep.accept(bot) shouldBe false
+    keep.accept(realSmall) shouldBe true
+    keep.accept(realOnTick) shouldBe true
   }
 }

--- a/src/test/scala/ai/metarank/config/SelectorYamlTest.scala
+++ b/src/test/scala/ai/metarank/config/SelectorYamlTest.scala
@@ -3,11 +3,13 @@ package ai.metarank.config
 import ai.metarank.config.Selector.{
   AcceptSelector,
   AndSelector,
+  CadenceSelector,
   FieldSelector,
   InteractionPositionSelector,
   NotSelector,
   RankingLengthSelector,
-  SampleSelector
+  SampleSelector,
+  UserSelector
 }
 import ai.metarank.ml.rank.NoopRanker.NoopConfig
 import org.scalatest.flatspec.AnyFlatSpec
@@ -92,6 +94,57 @@ class SelectorYamlTest extends AnyFlatSpec with Matchers {
     val result = parse(yaml).flatMap(_.as[ModelConfig])
     result shouldBe Right(
       NoopConfig(selector = RankingLengthSelector(minItems = Some(10), maxItems = None))
+    )
+  }
+
+  it should "load user selector" in {
+    val yaml =
+      """type: noop
+        |selector:
+        |  user: monitoring-bot""".stripMargin
+    val result = parse(yaml).flatMap(_.as[ModelConfig])
+    result shouldBe Right(NoopConfig(selector = UserSelector("monitoring-bot")))
+  }
+
+  it should "load cadence selector" in {
+    val yaml =
+      """type: noop
+        |selector:
+        |  periodSeconds: 300
+        |  secondFrom: 90
+        |  secondTo: 110""".stripMargin
+    val result = parse(yaml).flatMap(_.as[ModelConfig])
+    result shouldBe Right(NoopConfig(selector = CadenceSelector(300, 90, 110)))
+  }
+
+  it should "reject a cadence selector with a slot outside the period" in {
+    val yaml =
+      """type: noop
+        |selector:
+        |  periodSeconds: 300
+        |  secondFrom: 90
+        |  secondTo: 400""".stripMargin
+    parse(yaml).flatMap(_.as[ModelConfig]) shouldBe Symbol("left")
+  }
+
+  it should "load a combined synthetic-traffic exclusion selector" in {
+    val yaml =
+      """type: noop
+        |selector:
+        |  not:
+        |    and:
+        |      - minItems: 2
+        |        maxItems: 2
+        |      - periodSeconds: 300
+        |        secondFrom: 90
+        |        secondTo: 110""".stripMargin
+    val result = parse(yaml).flatMap(_.as[ModelConfig])
+    result shouldBe Right(
+      NoopConfig(selector =
+        NotSelector(
+          AndSelector(List(RankingLengthSelector(Some(2), Some(2)), CadenceSelector(300, 90, 110)))
+        )
+      )
     )
   }
 


### PR DESCRIPTION
- `UserSelector(user)` — matches a single user ID; useful for excluding a known bot account.
- `CadenceSelector(periodSeconds, secondFrom, secondTo)` — matches clickthroughs landing in a
  fixed slot of a repeating, epoch-aligned period, which is the shape synthetic monitoring
  traffic leaves behind. Decoder validates `0 <= secondFrom <= secondTo < periodSeconds`.

Combined with the existing `not`/`and`/`RankingLengthSelector` this can express “drop everything
that looks like the monitoring probe” without touching real traffic.