### PR TITLE
Defer closing a replaced model until later replacements retire it

### DIFF
--- a/src/main/scala/ai/metarank/fstore/cache/CachedModelStore.scala
+++ b/src/main/scala/ai/metarank/fstore/cache/CachedModelStore.scala
@@ -9,6 +9,7 @@ import cats.effect.IO
 import com.github.benmanes.caffeine.cache.RemovalCause
 import com.github.blemale.scaffeine.Scaffeine
 
+import java.util.concurrent.ArrayBlockingQueue
 import scala.concurrent.duration.*
 
 case class CachedModelStore(fast: ModelStore, slow: ModelStore) extends ModelStore {
@@ -29,15 +30,40 @@ case class CachedModelStore(fast: ModelStore, slow: ModelStore) extends ModelSto
 }
 
 object CachedModelStore extends Logging {
-  def createCache(ticker: EventTicker, size: Int = 32, expire: FiniteDuration = 1.hour) = Scaffeine()
-    .ticker(ticker)
-    .maximumSize(size)
-    .expireAfterAccess(expire)
-    .removalListener(disposeModel)
-    .build[ModelName, Model[?]]()
+  val retiredModelsSize = 4
 
-  def disposeModel(key: ModelName, model: Model[?], reason: RemovalCause): Unit = {
-    logger.info(s"removing model $key due to $reason")
-    model.close()
+  def createCache(ticker: EventTicker, size: Int = 32, expire: FiniteDuration = 1.hour) = {
+    val retired = new RetiredModels(retiredModelsSize)
+    Scaffeine()
+      .ticker(ticker)
+      .maximumSize(size)
+      .expireAfterAccess(expire)
+      .removalListener(disposeModel(retired))
+      .build[ModelName, Model[?]]()
+  }
+
+  def disposeModel(retired: RetiredModels)(key: ModelName, model: Model[?], reason: RemovalCause): Unit = reason match {
+    // Closing frees native memory an in-flight predict may still be reading
+    case RemovalCause.REPLACED =>
+      logger.debug(s"model $key was replaced, parking the previous instance")
+      retired.park(model)
+
+    case _ =>
+      logger.info(s"removing model $key due to $reason")
+      model.close()
+  }
+
+  // A parked model is closed after `capacity` further replacements, bounding retained native memory
+  class RetiredModels(capacity: Int) extends Logging {
+    private val parked = new ArrayBlockingQueue[Model[?]](capacity)
+
+    def park(model: Model[?]): Unit =
+      while (!parked.offer(model)) Option(parked.poll()).foreach(close)
+
+    def size(): Int = parked.size()
+
+    private def close(model: Model[?]): Unit =
+      try model.close()
+      catch { case e: Throwable => logger.warn(s"failed to close a parked model", e) }
   }
 }

--- a/src/test/scala/ai/metarank/fstore/cache/CachedModelStoreTest.scala
+++ b/src/test/scala/ai/metarank/fstore/cache/CachedModelStoreTest.scala
@@ -1,0 +1,63 @@
+package ai.metarank.fstore.cache
+
+import ai.metarank.fstore.Persistence.ModelName
+import ai.metarank.fstore.cache.CachedModelStore.RetiredModels
+import ai.metarank.ml.Model.RankModel
+import ai.metarank.ml.rank.QueryRequest
+import cats.effect.IO
+import com.github.benmanes.caffeine.cache.RemovalCause
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CachedModelStoreTest extends AnyFlatSpec with Matchers {
+  class ProbeModel(val name: String) extends RankModel {
+    var closed                                  = false
+    override def save()                         = None
+    override def predict(request: QueryRequest) = IO.raiseError(new Exception("not used"))
+    override def close(): Unit                  = closed = true
+    override def isClosed(): Boolean            = closed
+  }
+
+  it should "park a replaced model instead of closing it" in {
+    val model = new ProbeModel("standard")
+    CachedModelStore.disposeModel(new RetiredModels(4))(ModelName("standard"), model, RemovalCause.REPLACED)
+    model.closed shouldBe false
+  }
+
+  it should "close a model evicted for size or expiry" in {
+    for (cause <- List(RemovalCause.EXPIRED, RemovalCause.SIZE, RemovalCause.EXPLICIT)) {
+      val model = new ProbeModel("standard")
+      CachedModelStore.disposeModel(new RetiredModels(4))(ModelName("standard"), model, cause)
+      withClue(s"cause=$cause: ") { model.closed shouldBe true }
+    }
+  }
+
+  it should "keep parked models open up to its capacity" in {
+    val retired = new RetiredModels(2)
+    val models  = List.fill(2)(new ProbeModel("standard"))
+    models.foreach(retired.park)
+    models.map(_.closed) shouldBe List(false, false)
+    retired.size() shouldBe 2
+  }
+
+  it should "close the oldest parked model once capacity is exceeded" in {
+    val retired = new RetiredModels(2)
+    val models  = List.fill(4)(new ProbeModel("standard"))
+    models.foreach(retired.park)
+    // The two most recent stay open, so a request holding one still has a live model
+    models.map(_.closed) shouldBe List(true, true, false, false)
+    retired.size() shouldBe 2
+  }
+
+  it should "keep parking when a parked model throws on close" in {
+    val retired = new RetiredModels(1)
+    val bad = new ProbeModel("bad") {
+      override def close(): Unit = throw new RuntimeException("boom")
+    }
+    val good = new ProbeModel("good")
+    retired.park(bad)
+    retired.park(good)
+    good.closed shouldBe false
+    retired.size() shouldBe 1
+  }
+}


### PR DESCRIPTION
`CachedModelStore.createCache` closes the model for every removal cause, including `REPLACED` – but a replaced instance can still be held by an in-flight request, and `LambdaMARTModel.close` frees the native LightGBM booster that request’s `predict` call is reading — so this is a use-after-free, not merely a failed request.

Currently, when `REPLACED` fires, in a live serving process:
- `POST /train/{model}` retrains and calls  `store.models.put`, replacing the cached instance while traffic is being served. This is the dangerous one.
- Two concurrent cache misses for the same key both load from the slow store and both put; the  second replaces the first.
- A cached entry found closed is refetched and put over the top.

So proposed soultion parks the replaced instance in `RetiredModels`. Parking a model pushes the oldest out and closes that one. A request holding a just-replaced model always has a live instance, and retained memory is bounded at 4 models. Deferring by replacement count rather than wall time avoids needing a scheduler or a shutdown hook.
