### PR TITLE
Read S3 train parts in parallel, configurable via `readConcurrency`

### DIFF
--- a/doc/configuration/overview.md
+++ b/doc/configuration/overview.md
@@ -108,6 +108,8 @@ train:
   partSizeBytes: 10485760     # optional, pre-compression, default: 10Mb
   partSizeEvents: 1024        # optional, default: 1024 events
   partInterval: 1h            # optional, default: 1h
+  readConcurrency: 8          # optional, parts read in parallel during train,
+  # default: number of available CPUs, set to 1 for sequential reads
   endpoint: <endpoint URI>    # optional, custom S3 endpoint
   format: json | binary       # optional, default: binary
   awsKey: "<key>"             # optional, you should prefer setting

--- a/src/main/scala/ai/metarank/config/TrainConfig.scala
+++ b/src/main/scala/ai/metarank/config/TrainConfig.scala
@@ -37,6 +37,9 @@ object TrainConfig {
     case other          => Failure(new Exception(s"compression type $other not supported. Try gzip/zstd/none."))
   }
 
+  // How many train parts to download and decode concurrently in S3TrainStore.getall
+  val defaultReadConcurrency: Int = Runtime.getRuntime.availableProcessors()
+
   case class S3TrainConfig(
       awsKey: Option[String] = None,
       awsKeySecret: Option[String] = None,
@@ -47,6 +50,7 @@ object TrainConfig {
       partSizeBytes: Long = 10 * 1024 * 1024,
       partSizeEvents: Int = 1024,
       partInterval: FiniteDuration = 1.hour,
+      readConcurrency: Int = defaultReadConcurrency,
       endpoint: Option[String] = None,
       format: StoreFormat = BinaryStoreFormat
   ) extends TrainConfig
@@ -61,6 +65,7 @@ object TrainConfig {
       batchSizeBytes  <- c.downField("batchSizeBytes").as[Option[Long]]
       batchSizeEvents <- c.downField("batchSizeEvents").as[Option[Int]]
       partInterval    <- c.downField("partInterval").as[Option[FiniteDuration]]
+      readConcurrency <- c.downField("readConcurrency").as[Option[Int]]
       endpoint        <- c.downField("endpoint").as[Option[String]]
       format          <- c.downField("format").as[Option[StoreFormat]]
     } yield {
@@ -74,6 +79,7 @@ object TrainConfig {
         batchSizeBytes.getOrElse(1024 * 1024L),
         batchSizeEvents.getOrElse(1024),
         partInterval.getOrElse(1.hour),
+        readConcurrency.getOrElse(defaultReadConcurrency),
         endpoint,
         format.getOrElse(BinaryStoreFormat)
       )

--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -58,7 +58,7 @@ case class S3TrainStore(
           case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
         }
       )
-      .flatMap(key =>
+      .map(key =>
         // A single truncated/corrupt part (e.g. left behind by an interrupted or
         // concurrent write) must not abort the whole training run: log it and skip
         // the rest of that part, keeping the records already read from it and every
@@ -67,6 +67,7 @@ case class S3TrainStore(
           fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
         )
       )
+      .parJoin(conf.readConcurrency)
 
   def getPart(key: String): fs2.Stream[IO, TrainValues] = {
     fs2.Stream


### PR DESCRIPTION
Parts were downloaded and decoded strictly one at a time, so a train run over many small parts spent most of its wall time waiting on S3 round-trips. Replaces `flatMap` with `map` and `parJoin(conf.readConcurrency)`.

New `S3TrainConfig.readConcurrency`, default `availableProcessors`; set to 1 for the old sequential behaviour. Documented in `doc/configuration/overview.md`.

A side effect is that training parts arrive in nondeterministic order, so records no longer reach `predictor.fit` in sorted-by-key order. It’s harmless for LambdaMART, which collects everything before fitting.