### PR TITLE
Add support for HF retries on 429

### DIFF
--- a/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
+++ b/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
@@ -9,8 +9,9 @@ import cats.effect.IO
 import cats.effect.kernel.Resource
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
-import org.http4s.{EntityDecoder, Request, Uri}
+import org.http4s.{EntityDecoder, Request, Response, Status, Uri}
 import org.http4s.client.Client
+import org.http4s.client.middleware.{Retry, RetryPolicy}
 import org.http4s.circe.*
 import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.ci.CIString
@@ -81,13 +82,30 @@ object HuggingFaceClient {
   given modelSiblingCodec: Codec[Sibling]        = deriveCodec[Sibling]
   given modelResponseCodec: Codec[ModelResponse] = deriveCodec[ModelResponse]
 
+  val DEFAULT_MAX_RETRIES  = 5
+  val DEFAULT_MAX_RETRY_WAIT = 30.seconds
+
+  /** HuggingFace rate-limits anonymous downloads per IP with HTTP 429, which http4s does not treat as retriable by
+    * default. Retries GET requests on 429 + the standard 5xx/timeout set with exponential backoff, honouring the
+    * Retry-After header when present.
+    */
+  def withRetry(
+      client: Client[IO],
+      maxRetries: Int = DEFAULT_MAX_RETRIES,
+      maxWait: FiniteDuration = DEFAULT_MAX_RETRY_WAIT
+  )(using LoggerFactory[IO]): Client[IO] = {
+    val retriable: (Request[IO], Either[Throwable, Response[IO]]) => Boolean = (req, result) =>
+      RetryPolicy.defaultRetriable(req, result) || result.exists(_.status == Status.TooManyRequests)
+    Retry[IO](RetryPolicy(RetryPolicy.exponentialBackoff(maxWait, maxRetries), retriable))(client)
+  }
+
   def create(endpoint: String = HUGGINGFACE_API_ENDPOINT): Resource[IO, HuggingFaceClient] = {
     given logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
     for {
       uri    <- Resource.eval(IO.fromEither(Uri.fromString(endpoint)))
       client <- EmberClientBuilder.default[IO].withTimeout(200.seconds).build
     } yield {
-      HuggingFaceClient(client, uri)
+      HuggingFaceClient(withRetry(client), uri)
     }
   }
 

--- a/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
+++ b/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
@@ -82,7 +82,7 @@ object HuggingFaceClient {
   given modelSiblingCodec: Codec[Sibling]        = deriveCodec[Sibling]
   given modelResponseCodec: Codec[ModelResponse] = deriveCodec[ModelResponse]
 
-  val DEFAULT_MAX_RETRIES  = 5
+  val DEFAULT_MAX_RETRIES    = 5
   val DEFAULT_MAX_RETRY_WAIT = 30.seconds
 
   /** HuggingFace rate-limits anonymous downloads per IP with HTTP 429, which http4s does not treat as retriable by

--- a/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
+++ b/src/main/scala/ai/metarank/ml/onnx/HuggingFaceClient.scala
@@ -103,7 +103,7 @@ object HuggingFaceClient {
     given logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
     for {
       uri    <- Resource.eval(IO.fromEither(Uri.fromString(endpoint)))
-      client <- EmberClientBuilder.default[IO].withTimeout(200.seconds).build
+      client <- EmberClientBuilder.default[IO].withTimeout(Duration.Inf).withIdleConnectionTime(60.seconds).build
     } yield {
       HuggingFaceClient(withRetry(client), uri)
     }

--- a/src/test/scala/ai/metarank/util/HuggingFaceClientTest.scala
+++ b/src/test/scala/ai/metarank/util/HuggingFaceClientTest.scala
@@ -2,11 +2,62 @@ package ai.metarank.util
 
 import ai.metarank.ml.onnx.{HuggingFaceClient, ModelHandle}
 import ai.metarank.ml.onnx.HuggingFaceClient.ModelResponse.Sibling
+import cats.effect.{IO, Ref}
 import cats.effect.unsafe.implicits.global
+import org.http4s.{HttpApp, Response, Status, Uri}
+import org.http4s.client.Client
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.duration.*
+
 class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
+  given LoggerFactory[IO] = Slf4jFactory.create[IO]
+
+  // in-memory server: fails with `failStatus` for the first `failures` calls, then serves "ok"
+  def flakyClient(failures: Int, failStatus: Status): IO[(HuggingFaceClient, Ref[IO, Int])] = for {
+    counter <- Ref.of[IO, Int](0)
+    app = HttpApp[IO] { _ =>
+      counter.updateAndGet(_ + 1).map { n =>
+        if (n <= failures) Response[IO](failStatus) else Response[IO](Status.Ok).withEntity("ok")
+      }
+    }
+    raw = Client.fromHttpApp(app)
+    client = HuggingFaceClient.withRetry(raw, maxRetries = 3, maxWait = 10.millis)
+  } yield (HuggingFaceClient(client, Uri.unsafeFromString("http://localhost")), counter)
+
+  it should "retry on HTTP 429" in {
+    val (bytes, calls) = (for {
+      (client, counter) <- flakyClient(failures = 2, failStatus = Status.TooManyRequests)
+      bytes             <- client.modelFile(ModelHandle("metarank", "all-MiniLM-L6-v2"), "vocab.txt")
+      calls             <- counter.get
+    } yield (bytes, calls)).unsafeRunSync()
+    new String(bytes) shouldBe "ok"
+    calls shouldBe 3
+  }
+
+  it should "give up after max retries" in {
+    val (result, calls) = (for {
+      (client, counter) <- flakyClient(failures = 100, failStatus = Status.TooManyRequests)
+      result            <- client.modelFile(ModelHandle("metarank", "all-MiniLM-L6-v2"), "vocab.txt").attempt
+      calls             <- counter.get
+    } yield (result, calls)).unsafeRunSync()
+    result.left.map(_.getMessage) shouldBe Left("HTTP code 429")
+    calls shouldBe 4 // 1 attempt + 3 retries
+  }
+
+  it should "not retry on HTTP 404" in {
+    val (result, calls) = (for {
+      (client, counter) <- flakyClient(failures = 100, failStatus = Status.NotFound)
+      result            <- client.modelFile(ModelHandle("metarank", "all-MiniLM-L6-v2"), "vocab.txt").attempt
+      calls             <- counter.get
+    } yield (result, calls)).unsafeRunSync()
+    result.left.map(_.getMessage) shouldBe Left("HTTP code 404")
+    calls shouldBe 1
+  }
+
   it should "fetch metadata" in {
     val model = HuggingFaceClient
       .create()

--- a/src/test/scala/ai/metarank/util/HuggingFaceClientTest.scala
+++ b/src/test/scala/ai/metarank/util/HuggingFaceClientTest.scala
@@ -24,7 +24,7 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
         if (n <= failures) Response[IO](failStatus) else Response[IO](Status.Ok).withEntity("ok")
       }
     }
-    raw = Client.fromHttpApp(app)
+    raw    = Client.fromHttpApp(app)
     client = HuggingFaceClient.withRetry(raw, maxRetries = 3, maxWait = 10.millis)
   } yield (HuggingFaceClient(client, Uri.unsafeFromString("http://localhost")), counter)
 


### PR DESCRIPTION
## Retry HuggingFace downloads on 429

  CI flaked with `HTTP code 429` while pulling `tokenizer.json` for the cross-encoder model.                                                                                                                 

  ### Root cause

  `HuggingFaceClient` treats anything other than 200/302 as a hard failure. HF rate-limits anonymous downloads per IP, and GitHub runners share egress IPs, so a runner with an empty cache pulls ~90MB of onnx and gets throttled on the next small file.

  Also: the client sets `timeout=200s`, but Ember's idle timer stays at the default 60s and fires first on every socket read, so the 200s never applied. Ember warns about this on startup.

  ### Fix                                                                                                                                                                                                    

  - wrap the client in http4s `Retry` middleware with 429 added to the retriable set. Exponential backoff with jitter, `Retry-After` honoured.
  - header timeout to `Duration.Inf`, keep the 60s idle timer as the only guard.
  - offline tests for 429-then-200, always-429 and 404.



