### PR TITLE
abstract out mutable stuff into DeduplicateByKey

### DIFF
--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -4,8 +4,8 @@ import ai.metarank.config.TrainConfig.{CompressionType, S3TrainConfig}
 import ai.metarank.fstore.TrainStore
 import ai.metarank.fstore.clickthrough.S3TrainStore.{Buffer, format}
 import ai.metarank.fstore.codec.VCodec
-import ai.metarank.model.{EventId, TrainValues}
-import ai.metarank.util.Logging
+import ai.metarank.model.TrainValues
+import ai.metarank.util.{DeduplicateByKey, Logging}
 import cats.effect.{IO, Ref}
 import cats.effect.kernel.Resource
 import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
@@ -68,13 +68,7 @@ case class S3TrainStore(
         )
       )
 
-    if (conf.deduplicate)
-      // Suspend so each materialisation of the stream gets its own seen-set
-      fs2.Stream.suspend {
-        val seen = scala.collection.mutable.HashSet.empty[EventId]
-        parts.filter(tv => seen.add(tv.id))
-      }
-    else parts
+    parts.through(if (conf.deduplicate) DeduplicateByKey(_.id) else identity)
   }
 
   def getPart(key: String): fs2.Stream[IO, TrainValues] = {

--- a/src/main/scala/ai/metarank/util/DeduplicateByKey.scala
+++ b/src/main/scala/ai/metarank/util/DeduplicateByKey.scala
@@ -1,0 +1,22 @@
+package ai.metarank.util
+
+import cats.effect.IO
+import fs2.{Pipe, Pull, Stream}
+
+/** Drops every element whose key was already seen earlier in the stream, keeping the first occurrence. The seen-set is
+  * carried as Pull state, so each run of the stream starts fresh. Memory grows with the number of distinct keys.
+  */
+object DeduplicateByKey {
+  def apply[T, K](key: T => K): Pipe[IO, T, T] = {
+    def next(s: Stream[IO, T], seen: Set[K]): Pull[IO, T, Unit] = {
+      s.pull.uncons1.flatMap {
+        case Some((item, tail)) =>
+          val k = key(item)
+          if (seen.contains(k)) next(tail, seen)
+          else Pull.output1(item) >> next(tail, seen + k)
+        case None => Pull.done
+      }
+    }
+    in => next(in, Set.empty).stream
+  }
+}

--- a/src/test/scala/ai/metarank/util/DeduplicateByKeyTest.scala
+++ b/src/test/scala/ai/metarank/util/DeduplicateByKeyTest.scala
@@ -1,0 +1,43 @@
+package ai.metarank.util
+
+import ai.metarank.util.DeduplicateByKeyTest.KV
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DeduplicateByKeyTest extends AnyFlatSpec with Matchers {
+  it should "keep the first occurrence and drop later ones by key" in {
+    val result = make(fs2.Stream(KV("a", 1), KV("b", 2), KV("a", 3), KV("c", 4), KV("b", 5), KV("a", 6)))
+    result shouldBe List(KV("a", 1), KV("b", 2), KV("c", 4))
+  }
+
+  it should "handle empty stream" in {
+    make(fs2.Stream.empty) shouldBe Nil
+  }
+
+  it should "pass through a stream without duplicates" in {
+    val source = List(KV("a", 1), KV("b", 2), KV("c", 3))
+    make(fs2.Stream(source*)) shouldBe source
+  }
+
+  it should "drop duplicates across concatenated streams" in {
+    val first  = fs2.Stream(KV("a", 1), KV("b", 2))
+    val second = fs2.Stream(KV("b", 3), KV("c", 4), KV("a", 5))
+    make(first ++ second) shouldBe List(KV("a", 1), KV("b", 2), KV("c", 4))
+  }
+
+  it should "start with a fresh seen-set on every run" in {
+    val stream = fs2.Stream(KV("a", 1), KV("a", 2)).through(DeduplicateByKey[KV, String](_.k))
+    stream.compile.toList.unsafeRunSync() shouldBe List(KV("a", 1))
+    stream.compile.toList.unsafeRunSync() shouldBe List(KV("a", 1))
+  }
+
+  def make(source: fs2.Stream[IO, KV]): List[KV] = {
+    source.through(DeduplicateByKey[KV, String](_.k)).compile.toList.unsafeRunSync()
+  }
+}
+
+object DeduplicateByKeyTest {
+  case class KV(k: String, v: Int)
+}


### PR DESCRIPTION
## Follow-up to #1682: move dedup into a `DeduplicateByKey` pipe
  
#1682 inlined the dedup in `S3TrainStore.getall()` as a `mutable.HashSet` inside `Stream.suspend`. It works, but it's the only stream in the codebase closing over mutable state, and the `suspend` trick is easy to break on the next refactor.

  ### What changed
  
  * new `ai.metarank.util.DeduplicateByKey`: a `Pull`-based pipe carrying an immutable `Set` of seen keys. First occurrence wins, state is per run.                                                          
  * `getall()` becomes `parts.through(if (conf.deduplicate) DeduplicateByKey(_.id) else identity)`.
  * unit test for the pipe.

