### PR TITLE
bump ltrlib to 0.3.0 to fix crash on close

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val root = (project in file("."))
       "org.http4s"             %% "http4s-circe"             % http4sVersion,
       "org.typelevel"          %% "log4cats-core"            % log4catsVersion,
       "org.typelevel"          %% "log4cats-slf4j"           % log4catsVersion,
-      "io.github.metarank"     %% "ltrlib"                   % "0.2.6",
+      "io.github.metarank"     %% "ltrlib"                   % "0.3.0",
       "io.github.metarank"      % "lightgbm4j"               % "4.6.0-2",
       "com.github.ua-parser"    % "uap-java"                 % "1.6.1",
       "org.apache.lucene"       % "lucene-core"              % luceneVersion,

--- a/src/test/scala/ai/metarank/ml/rank/LambdaMARTModelCloseTest.scala
+++ b/src/test/scala/ai/metarank/ml/rank/LambdaMARTModelCloseTest.scala
@@ -1,0 +1,93 @@
+package ai.metarank.ml.rank
+
+import ai.metarank.config.BoosterConfig.LightGBMConfig
+import ai.metarank.ml.rank.LambdaMARTRanker.{LambdaMARTConfig, LambdaMARTModel}
+import ai.metarank.model.Event.RankItem
+import ai.metarank.model.Identifier.ItemId
+import ai.metarank.model.Key.FeatureName
+import ai.metarank.model.Timestamp
+import better.files.Resource
+import cats.data.NonEmptyList
+import cats.effect.unsafe.implicits.global
+import io.github.metarank.ltrlib.booster.LightGBMBooster
+import io.github.metarank.ltrlib.model.Query
+import org.apache.commons.io.IOUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import scala.util.Random
+
+/** Regression for the native use-after-free: closing a LambdaMART model from another thread (Caffeine removal listener)
+  * while a predict is running used to free the LightGBM booster mid-call and crash the JVM.
+  */
+class LambdaMARTModelCloseTest extends AnyFlatSpec with Matchers {
+  val modelBytes = IOUtils.toByteArray(Resource.my.getAsStream("/ranklens/ranklens.model"))
+  val features   = 32 // ranklens.model was trained on 32 features
+  val conf = LambdaMARTConfig(
+    backend = LightGBMConfig(),
+    features = NonEmptyList.one(FeatureName("foo")),
+    weights = Map("click" -> 1.0)
+  )
+
+  def loadModel() = LambdaMARTModel("lgbm", conf, LightGBMBooster.apply(modelBytes))
+
+  def request(rows: Int): QueryRequest = QueryRequest(
+    items = NonEmptyList.fromListUnsafe((0 until rows).map(i => RankItem(ItemId(s"p$i"))).toList),
+    user = None,
+    session = None,
+    ts = Timestamp.now,
+    query = Query(0, new Array[Double](rows), Array.fill(rows * features)(Random.nextDouble()))
+  )
+
+  it should "survive a close from another thread while predicting" in {
+    // repeat with fresh boosters so the close lands at different points of the native call
+    for (round <- 1 to 20) {
+      val model       = loadModel()
+      val req         = request(100)
+      val successes   = new AtomicInteger(0)
+      val unexpected  = new AtomicReference[Option[Throwable]](None)
+      val warmedUp    = new CountDownLatch(1)
+      val sawClosed   = new CountDownLatch(1)
+
+      val inference = new Thread(
+        () => {
+          var running = true
+          while (running) {
+            try {
+              val scores = model.predict(req).unsafeRunSync()
+              scores.items.size shouldBe 100
+              successes.incrementAndGet()
+              if (successes.get() == 10) warmedUp.countDown()
+            } catch {
+              case _: IllegalStateException => sawClosed.countDown(); running = false
+              case e: Throwable             => unexpected.set(Some(e)); running = false
+            }
+          }
+        },
+        s"inference-$round"
+      )
+      val closer = new Thread(
+        () => {
+          warmedUp.await()
+          model.close()
+        },
+        s"closer-$round"
+      )
+
+      inference.start()
+      closer.start()
+      closer.join()
+      inference.join()
+
+      withClue(s"round $round: ") {
+        unexpected.get() shouldBe None
+        successes.get() should be >= 10
+        sawClosed.getCount shouldBe 0
+        model.isClosed() shouldBe true
+        an[IllegalStateException] should be thrownBy model.predict(req).unsafeRunSync()
+      }
+    }
+  }
+}

--- a/src/test/scala/ai/metarank/ml/rank/LambdaMARTModelCloseTest.scala
+++ b/src/test/scala/ai/metarank/ml/rank/LambdaMARTModelCloseTest.scala
@@ -44,12 +44,12 @@ class LambdaMARTModelCloseTest extends AnyFlatSpec with Matchers {
   it should "survive a close from another thread while predicting" in {
     // repeat with fresh boosters so the close lands at different points of the native call
     for (round <- 1 to 20) {
-      val model       = loadModel()
-      val req         = request(100)
-      val successes   = new AtomicInteger(0)
-      val unexpected  = new AtomicReference[Option[Throwable]](None)
-      val warmedUp    = new CountDownLatch(1)
-      val sawClosed   = new CountDownLatch(1)
+      val model      = loadModel()
+      val req        = request(100)
+      val successes  = new AtomicInteger(0)
+      val unexpected = new AtomicReference[Option[Throwable]](None)
+      val warmedUp   = new CountDownLatch(1)
+      val sawClosed  = new CountDownLatch(1)
 
       val inference = new Thread(
         () => {


### PR DESCRIPTION
## Native crash on model close while serving

  Fixes the SIGSEGV we get when a LambdaMART model is closed while another thread is inside `predict`. Alternative to #1687.

  ### Root cause
  
  `CachedModelStore` frees the model from the Caffeine removal listener on every eviction: retrain via `POST /train`, expiry, size, two concurrent cache misses replacing each other. The listener runs on  Caffeine's executor, so `booster.close()` lands on a different thread than the request. On the ltrlib side the only guard was `whenNotClosed`, a plain boolean check with no synchronization. A predict that passed the check and entered LightGBM native code could have its booster freed underneath it. Use-after-free, JVM dies.

  #1687 parks the last 4 replaced models in a queue. That makes the window longer but doesn't close it, only handles the `REPLACED` cause, and leaks 4 boosters of native memory forever if no further retrain happens.

  ### Fix

  Moved to ltrlib 0.3.0, where the native handle lives. `Booster.close()` now only marks the booster as closed and counts in-flight `whenNotClosed` calls. If something is running, the actual native release happens when the last call exits. `close()` never blocks, so the Caffeine listener stays cheap. Covers LightGBM, XGBoost and CatBoost. As a bonus, XGBoost and CatBoost previously never set the closed flag at all, so `isClosed` was always false and a double close disposed twice.

  Metarank only needs the version bump. `LambdaMARTModel` already delegates `close`/`isClosed` to the booster, and `CachedModelStore` on master becomes safe as is.

  ### Test

  `LambdaMARTModelCloseTest` loads the ranklens LightGBM model and runs one thread hammering `predict` and another one calling `close` mid-way, 20 rounds with fresh boosters. On ltrlib 0.2.6 it crashes the JVM   with SIGSEGV on the first round. On 0.3.0 it passes.

