### PR TITLE
add explicit ordering for concurrent download

### DIFF
--- a/doc/configuration/overview.md
+++ b/doc/configuration/overview.md
@@ -108,7 +108,7 @@ train:
   partSizeBytes: 10485760     # optional, pre-compression, default: 10Mb
   partSizeEvents: 1024        # optional, default: 1024 events
   partInterval: 1h            # optional, default: 1h
-  readConcurrency: 8          # optional, parts read in parallel during train,
+  readConcurrency: 8          # optional, parts downloaded in parallel during train (decoded in order),
   # default: number of available CPUs, set to 1 for sequential reads
   endpoint: <endpoint URI>    # optional, custom S3 endpoint
   format: json | binary       # optional, default: binary

--- a/src/main/scala/ai/metarank/config/TrainConfig.scala
+++ b/src/main/scala/ai/metarank/config/TrainConfig.scala
@@ -37,7 +37,7 @@ object TrainConfig {
     case other          => Failure(new Exception(s"compression type $other not supported. Try gzip/zstd/none."))
   }
 
-  // How many train parts to download and decode concurrently in S3TrainStore.getall
+  // How many train parts to download concurrently in S3TrainStore.getall; parts are decoded sequentially in key order
   val defaultReadConcurrency: Int = Runtime.getRuntime.availableProcessors()
 
   case class S3TrainConfig(

--- a/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
+++ b/src/main/scala/ai/metarank/fstore/clickthrough/S3TrainStore.scala
@@ -60,40 +60,35 @@ case class S3TrainStore(
           case None    => warn(s"part $key has an unsupported extension (expected .gz/.zst/.bin), skipping").as(false)
         }
       )
-      .map(key =>
-        // A single truncated/corrupt part (e.g. left behind by an interrupted or
-        // concurrent write) must not abort the whole training run: log it and skip
-        // the rest of that part, keeping the records already read from it and every
-        // other part.
-        getPart(key).handleErrorWith(e =>
-          fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))
-        )
+      .parEvalMap(conf.readConcurrency)(key =>
+        fetchPart(key)
+          .map(path => readPart(key, path))
+          .handleErrorWith(e => warn(s"skipping undownloadable train part $key: ${e.getMessage}").as(fs2.Stream.empty))
+          .map(_.handleErrorWith(e => fs2.Stream.exec(warn(s"skipping unreadable train part $key: ${e.getMessage}"))))
       )
-      .parJoin(conf.readConcurrency)
+      .flatten
 
     parts.through(if (conf.deduplicate) DeduplicateByKey(_.id) else identity)
   }
 
-  def getPart(key: String): fs2.Stream[IO, TrainValues] = {
-    fs2.Stream
-      .eval(for {
-        file <- IO(Path.of(tmpdir, key))
-        _    <- IO(Files.createDirectories(file.getParent))
-        head <- IO.fromCompletableFuture(
-          IO(client.headObject(HeadObjectRequest.builder().bucket(conf.bucket).key(key).build()))
-        )
-        remoteSize <- IO(head.contentLength().longValue())
-        cached     <- IO(Files.exists(file) && Files.size(file) == remoteSize)
-        _ <-
-          if (cached) info(s"found part $key in local cache, size=${FileUtils.byteCountToDisplaySize(remoteSize)}")
-          else downloadPart(key, file, remoteSize)
-      } yield {
-        file
-      })
-      .flatMap(path =>
-        fs2.Stream.bracket(IO(new FileInputStream(path.toFile)))(s => IO(s.close())).flatMap(s => read(s, key))
-      )
+  // Resolve a part to a local file: reuse the cached copy when its size matches S3, otherwise download.
+  def fetchPart(key: String): IO[Path] = for {
+    file <- IO(Path.of(tmpdir, key))
+    _    <- IO(Files.createDirectories(file.getParent))
+    head <- IO.fromCompletableFuture(
+      IO(client.headObject(HeadObjectRequest.builder().bucket(conf.bucket).key(key).build()))
+    )
+    remoteSize <- IO(head.contentLength().longValue())
+    cached     <- IO(Files.exists(file) && Files.size(file) == remoteSize)
+    _ <-
+      if (cached) info(s"found part $key in local cache, size=${FileUtils.byteCountToDisplaySize(remoteSize)}")
+      else downloadPart(key, file, remoteSize)
+  } yield {
+    file
   }
+
+  def readPart(key: String, path: Path): fs2.Stream[IO, TrainValues] =
+    fs2.Stream.bracket(IO(new FileInputStream(path.toFile)))(s => IO(s.close())).flatMap(s => read(s, key))
 
   def downloadPart(key: String, file: Path, size: Long): IO[Unit] = for {
     tmp     <- IO(file.resolveSibling(file.getFileName.toString + ".tmp." + UUID.randomUUID().toString.take(8)))


### PR DESCRIPTION
  #1692 made `S3TrainStore.getall` read parts in parallel with `parJoin`. It merges records in whatever order the parts finish decoding, so the train stream is now nondeterministic between runs. Three consumers quietly assumed the old sorted-by-key order:

  - warmup sampling in `LambdaMARTPredictor.fit` keeps the first N clickthroughs it sees                                                                                                           
  - `deduplicate: true` keeps the first copy of a record                                                                                                                                                     
  - item metadata updates land in the KNN index last-wins

  None of these break outright, but the same bucket can now produce a different model on every run, and there's no way to tell that from a real data change.

  ## Fix

  The latency we wanted to hide is in S3 round-trips, not in decoding. So the part read is split in two: `fetchPart` downloads to the local cache, `readPart` decodes a file. Downloads still run `readConcurrency` at a time, but through `parEvalMap`, which emits in input order. Parts are then decoded one after another in sorted key order, same as before #1692.

  A part that fails to download or decode is still logged and skipped instead of failing the run.

  ## Notes

  - `readConcurrency` keeps its meaning, only the doc comment changed to say decoding is sequential.
  - No new tests: the existing S3 tests don't cover `getall`, and stubbing S3 for an ordering test didn't seem worth it here.

