### PR TITLE
Import train data once and reuse it for all configured models

### DIFF
--- a/src/main/scala/ai/metarank/main/command/Train.scala
+++ b/src/main/scala/ai/metarank/main/command/Train.scala
@@ -7,7 +7,7 @@ import ai.metarank.fstore.memory.MemPersistence
 import ai.metarank.main.CliArgs.TrainArgs
 import ai.metarank.ml.{Context, Model, Predictor}
 import ai.metarank.ml.rank.LambdaMARTRanker.{LambdaMARTModel, LambdaMARTPredictor}
-import ai.metarank.model.TrainResult
+import ai.metarank.model.{TrainResult, TrainValues}
 import ai.metarank.model.TrainResult.FeatureStatus
 import ai.metarank.util.Logging
 import cats.effect.IO
@@ -34,29 +34,33 @@ object Train extends Logging {
               ).map(x => Map(x._1 -> x._2))
             case None => info(s"Training all models: ${mapping.models.keys.toList}") *> IO.pure(mapping.models)
           }
-          _ <- models.toList
-            .map { case (name, pred) =>
-              store match {
-                case MemPersistence(_) =>
-                  IO.raiseError(
-                    new Exception(
-                      """=======
-                        |You're using an in-mem persistence and invoked a train sub-command.
-                        |In-mem persistence is not actually persisting anything between metarank invocations,
-                        |so it has zero saved click-through records for model training.
-                        |
-                        |You probably need to enable redis persistence in the config file, or use
-                        |a standalone mode (which imports data and trains ML model within a single
-                        |JVM process)
-                        |=======""".stripMargin
-                    )
-                  )
-                case _ =>
-                  train(store, cts, pred).void
-              }
-            }
-            .sequence
-            .void
+          _ <- store match {
+            case MemPersistence(_) =>
+              IO.raiseError(
+                new Exception(
+                  """=======
+                    |You're using an in-mem persistence and invoked a train sub-command.
+                    |In-mem persistence is not actually persisting anything between metarank invocations,
+                    |so it has zero saved click-through records for model training.
+                    |
+                    |You probably need to enable redis persistence in the config file, or use
+                    |a standalone mode (which imports data and trains ML model within a single
+                    |JVM process)
+                    |=======""".stripMargin
+                )
+              )
+            case _ => IO.unit
+          }
+          _ <- models.toList match {
+            // A single model needs no buffering, so keep streaming it straight into fit
+            case (_, pred) :: Nil => train(store, cts, pred).void
+            case many =>
+              for {
+                data <- cts.getall().compile.toVector
+                _    <- info(s"loaded ${data.size} train records, reused across ${many.size} models")
+                _    <- many.traverse { case (_, pred) => trainShared(store, data, pred) }.void
+              } yield {}
+          }
         } yield {
           logger.info("Training finished")
         }
@@ -68,8 +72,22 @@ object Train extends Logging {
       store: Persistence,
       cts: TrainStore,
       predictor: Predictor[? <: ModelConfig, ?, ? <: Model[? <: Context]]
+  ): IO[TrainResult] =
+    fitAndStore(store, cts.getall(), predictor)
+
+  def trainShared(
+      store: Persistence,
+      data: Vector[TrainValues],
+      predictor: Predictor[? <: ModelConfig, ?, ? <: Model[? <: Context]]
+  ): IO[TrainResult] =
+    fitAndStore(store, fs2.Stream.emits(data).covary[IO], predictor)
+
+  private def fitAndStore(
+      store: Persistence,
+      data: fs2.Stream[IO, TrainValues],
+      predictor: Predictor[? <: ModelConfig, ?, ? <: Model[? <: Context]]
   ): IO[TrainResult] = for {
-    model <- predictor.fit(cts.getall().filter(c => predictor.config.selector.accept(c)))
+    model <- predictor.fit(data.filter(c => predictor.config.selector.accept(c)))
     weights = (model, predictor) match {
       case (m: LambdaMARTModel, p: LambdaMARTPredictor) =>
         m.weights(p.desc).map { case (name, w) => FeatureStatus(name, w) }


### PR DESCRIPTION
`Train.run` calls `cts.getall` once per model, so training _n_ models downloads and decodes the whole train store _n_ times. This PR suggest reading the store once and feeding every model from it. The drawback is higher memory usage.

A single configured model keeps the streaming path and never buffers, so there is no memory regression for the common case. The per-model selector filter moved into a shared `fitAndStore`; the single-model `train(store, cts, predictor)` entry point is untouched and still used by `TrainApi`, `Standalone` and the tests.